### PR TITLE
Use C++20 and designated initializers in Tiny demos

### DIFF
--- a/samples/desktop/CMakeLists.txt
+++ b/samples/desktop/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 macro(ADD_DEMO app)
   add_executable(${app} "Tiny/${app}.cpp")
-  igl_set_cxxstd(${app} 17)
+  igl_set_cxxstd(${app} 20)
   igl_set_folder(${app} ${PROJECT_NAME})
   target_link_libraries(${app} PUBLIC IGLLibrary)
   target_link_libraries(${app} PRIVATE bc7enc)

--- a/samples/desktop/Tiny/Tiny.cpp
+++ b/samples/desktop/Tiny/Tiny.cpp
@@ -207,8 +207,12 @@ static void initIGL() {
     device_ = std::make_unique<igl::opengl::glx::Device>(std::move(ctx));
 #endif
 #else
-    igl::vulkan::VulkanContextConfig cfg{8, 8, true};
-    cfg.swapChainColorSpace = igl::ColorSpace::SRGB_LINEAR;
+    const igl::vulkan::VulkanContextConfig cfg{
+        .maxTextures = 8,
+        .maxSamplers = 8,
+        .terminateOnValidationError = true,
+        .swapChainColorSpace = igl::ColorSpace::SRGB_LINEAR,
+    };
 #ifdef _WIN32
     auto ctx = vulkan::HWDevice::createContext(cfg, (void*)glfwGetWin32Window(window_));
 #elif __APPLE__

--- a/samples/desktop/Tiny/Tiny_Mesh.cpp
+++ b/samples/desktop/Tiny/Tiny_Mesh.cpp
@@ -138,7 +138,6 @@ struct UniformsPerObject {
   mat4 model;
 };
 
-// from igl/shell/renderSessions/Textured3DCubeSession.cpp
 const float half = 1.0f;
 
 // UV-mapped cube with indices: 24 vertices, 36 indices
@@ -249,8 +248,12 @@ static bool initWindow(GLFWwindow** outWindow) {
 static void initIGL() {
   // create a device
   {
-    igl::vulkan::VulkanContextConfig cfg{128, 128, true};
-    cfg.swapChainColorSpace = igl::ColorSpace::SRGB_LINEAR;
+    const igl::vulkan::VulkanContextConfig cfg = {
+        .maxTextures = 128,
+        .maxSamplers = 128,
+        .terminateOnValidationError = true,
+        .swapChainColorSpace = igl::ColorSpace::SRGB_LINEAR,
+    };
 #ifdef _WIN32
     auto ctx = vulkan::HWDevice::createContext(cfg, (void*)glfwGetWin32Window(window_));
 #elif __APPLE__

--- a/samples/desktop/Tiny/Tiny_MeshLarge.cpp
+++ b/samples/desktop/Tiny/Tiny_MeshLarge.cpp
@@ -933,9 +933,14 @@ void initIGL() {
 
 #endif
 #else
-      igl::vulkan::VulkanContextConfig cfg{
-          kMaxTextures, 128, true, true, false, kEnableValidationLayers};
-      cfg.swapChainColorSpace = igl::ColorSpace::SRGB_LINEAR;
+  const igl::vulkan::VulkanContextConfig cfg = {
+      .maxTextures = kMaxTextures,
+      .maxSamplers = 128,
+      .terminateOnValidationError = true,
+      .enhancedShaderDebugging = true,
+      .enableValidation = kEnableValidationLayers,
+      .swapChainColorSpace = igl::ColorSpace::SRGB_LINEAR,
+  };
 #ifdef _WIN32
       auto ctx = vulkan::HWDevice::createContext(cfg, (void*)glfwGetWin32Window(window_));
 


### PR DESCRIPTION
Use C++20 and designated initializers in Tiny demos to prevent `VulkanContextConfig` initialization mistakes.