### PR TITLE
Fixed compiler errors that were occuring on Fedora

### DIFF
--- a/shell/shared/fileLoader/FileLoader.h
+++ b/shell/shared/fileLoader/FileLoader.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <stdint.h>
 #include <string>
 #include <vector>
 

--- a/shell/shared/imageLoader/win/ImageLoaderWin.cpp
+++ b/shell/shared/imageLoader/win/ImageLoaderWin.cpp
@@ -6,6 +6,8 @@
  */
 
 #include "stb_image.h"
+#include <stdint.h>
+#include <cstring>
 #include <filesystem>
 #include <shell/shared/imageLoader/win/ImageLoaderWin.h>
 


### PR DESCRIPTION
Included cstring and stdint header files.
I ran into the following errors on Fedora:
```
In file included from /home/bkeys/Devel/igl/shell/shared/fileLoader/win/FileLoaderWin.cpp:8:
In file included from /home/bkeys/Devel/igl/./shell/shared/fileLoader/win/FileLoaderWin.h:10:
/home/bkeys/Devel/igl/./shell/shared/fileLoader/FileLoader.h:18:23: error: use of undeclared identifier 'uint8_t'
  virtual std::vector<uint8_t> loadBinaryData(const std::string& /* filename */) {
                      ^
/home/bkeys/Devel/igl/./shell/shared/fileLoader/FileLoader.h:19:24: error: use of undeclared identifier 'uint8_t'
    return std::vector<uint8_t>();
                       ^
In file included from /home/bkeys/Devel/igl/shell/shared/fileLoader/win/FileLoaderWin.cpp:8:
/home/bkeys/Devel/igl/./shell/shared/fileLoader/win/FileLoaderWin.h:18:15: error: use of undeclared identifier 'uint8_t'
  std::vector<uint8_t> loadBinaryData(const std::string& fileName) override;
              ^
In file included from /home/bkeys/Devel/igl/shell/shared/platform/win/PlatformWin.cpp:8:
In file included from /home/bkeys/Devel/igl/./shell/shared/platform/win/PlatformWin.h:10:
/home/bkeys/Devel/igl/./shell/shared/fileLoader/FileLoader.h:18:23: error: use of undeclared identifier 'uint8_t'
  virtual std::vector<uint8_t> loadBinaryData(const std::string& /* filename */) {
                      ^
/home/bkeys/Devel/igl/./shell/shared/fileLoader/FileLoader.h:19:24: error: use of undeclared identifier 'uint8_t'
    return std::vector<uint8_t>();
                       ^
/home/bkeys/Devel/igl/shell/shared/fileLoader/win/FileLoaderWin.cpp:16:13: error: use of undeclared identifier 'uint8_t'
std::vector<uint8_t> FileLoaderWin::loadBinaryData(const std::string& fileName) {
            ^
/home/bkeys/Devel/igl/shell/shared/fileLoader/win/FileLoaderWin.cpp:17:15: error: use of undeclared identifier 'uint8_t'
  std::vector<uint8_t> data;
              ^
/home/bkeys/Devel/igl/shell/shared/fileLoader/win/FileLoaderWin.cpp:31:51: error: use of undeclared identifier 'uint8_t'
  data.insert(data.begin(), std::istream_iterator<uint8_t>(file), std::istream_iterator<uint8_t>());
                                                  ^
/home/bkeys/Devel/igl/shell/shared/fileLoader/win/FileLoaderWin.cpp:31:89: error: use of undeclared identifier 'uint8_t'
  data.insert(data.begin(), std::istream_iterator<uint8_t>(file), std::istream_iterator<uint8_t>());
                                                                                        ^
7 errors generated.
make[2]: *** [shell/windows/CMakeFiles/IGLShellPlatform.dir/build.make:76: shell/windows/CMakeFiles/IGLShellPlatform.dir/__/shared/fileLoader/win/FileLoaderWin.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/bkeys/Devel/igl/shell/shared/platform/win/PlatformWin.cpp:10:
/home/bkeys/Devel/igl/./shell/shared/fileLoader/win/FileLoaderWin.h:18:68: error: only virtual member functions can be marked 'override'
  std::vector<uint8_t> loadBinaryData(const std::string& fileName) override;
                                                                   ^~~~~~~~
3 errors generated.
make[2]: *** [shell/windows/CMakeFiles/IGLShellPlatform.dir/build.make:118: shell/windows/CMakeFiles/IGLShellPlatform.dir/__/shared/platform/win/PlatformWin.cpp.o] Error 1
/home/bkeys/Devel/igl/shell/shared/imageLoader/win/ImageLoaderWin.cpp:70:3: error: use of undeclared identifier 'memcpy'; did you mean 'wmemcpy'?
  memcpy(ret.buffer.data(), data, ret.bytesPerRow * ret.height);
  ^~~~~~
  wmemcpy
/usr/include/wchar.h:263:17: note: 'wmemcpy' declared here
extern wchar_t *wmemcpy (wchar_t *__restrict __s1,
                ^
/home/bkeys/Devel/igl/shell/shared/imageLoader/win/ImageLoaderWin.cpp:70:10: error: cannot initialize a parameter of type 'wchar_t *' with an rvalue of type 'unsigned char *'
  memcpy(ret.buffer.data(), data, ret.bytesPerRow * ret.height);
         ^~~~~~~~~~~~~~~~~
/usr/include/wchar.h:263:46: note: passing argument to parameter '__s1' here
extern wchar_t *wmemcpy (wchar_t *__restrict __s1,
                                             ^
2 errors generated.
```
This pull request causes the build to run just fine on Fedora.