### PR TITLE
Fix many typos

### DIFF
--- a/IGLU/imgui/Session.cpp
+++ b/IGLU/imgui/Session.cpp
@@ -294,7 +294,7 @@ void Session::Renderer::newFrame(const igl::FramebufferDesc& desc) {
 }
 
 namespace {
-// push constant structure for Vulkan, containing all the relavent data
+// push constant structure for Vulkan, containing all the relevant data
 struct VulkanImguiBindData {
   iglu::simdtypes::float4x4 proj;
   uint32_t textureId;

--- a/IGLU/managedUniformBuffer/ManagedUniformBuffer.cpp
+++ b/IGLU/managedUniformBuffer/ManagedUniformBuffer.cpp
@@ -107,7 +107,7 @@ ManagedUniformBuffer::ManagedUniformBuffer(igl::IDevice& device,
 ManagedUniformBuffer::~ManagedUniformBuffer() {
 #if IGL_PLATFORM_IOS_SIMULATOR
   if (vmAllocLength_) {
-    // if vmAllocLength_ is nonzero it implies we uesd vm_alloc to allocate the memory
+    // if vmAllocLength_ is nonzero it implies we used vm_alloc to allocate the memory
     vm_deallocate((vm_map_t)mach_task_self(), (vm_address_t)data_, vmAllocLength_);
   } else {
 #endif

--- a/IGLU/simple_renderer/Material.h
+++ b/IGLU/simple_renderer/Material.h
@@ -94,7 +94,7 @@ class Material final {
   DepthTestConfig depthTestConfig() const;
   void setDepthTestConfig(igl::IDevice& device, const DepthTestConfig& config);
 
-  /// Populates a pipeline decriptor for drawing using this Material.
+  /// Populates a pipeline descriptor for drawing using this Material.
   void populatePipelineDescriptor(igl::RenderPipelineDesc& pipelineDesc) const;
 
   /// Binds all relevant states in 'encoder' in preparation for drawing.

--- a/IGLU/simple_renderer/ShaderProgram.h
+++ b/IGLU/simple_renderer/ShaderProgram.h
@@ -23,7 +23,7 @@ class ShaderProgram final {
   /// layout of the uniforms within a shader.
   const igl::IRenderPipelineReflection& renderPipelineReflection() const;
 
-  /// Populates a pipeline decriptor for drawing using this shader program.
+  /// Populates a pipeline descriptor for drawing using this shader program.
   void populatePipelineDescriptor(igl::RenderPipelineDesc& pipelineDesc) const;
 
   ShaderProgram(igl::IDevice& device,

--- a/getting-started.md
+++ b/getting-started.md
@@ -20,7 +20,7 @@ A complex example demonstrating most of IGL features and rendering the Lumberyar
 
 # RenderSessions
 
-RenderSessions use iglshell functionality that provides platfrom abstraction and basic application functionality.
+RenderSessions use iglshell functionality that provides platform abstraction and basic application functionality.
 We provide some basic examples that you can use in your projects
 
 1)  [EmptySession](./shell/renderSessions/EmptySession.cpp)

--- a/shell/openxr/mobile/XrApp.h
+++ b/shell/openxr/mobile/XrApp.h
@@ -33,7 +33,7 @@ class XrApp {
   XrApp(std::unique_ptr<impl::XrAppImpl>&& impl);
   ~XrApp();
 
-  inline bool intialized() const {
+  inline bool initialized() const {
     return initialized_;
   }
   bool initialize(const struct android_app* app);

--- a/shell/renderSessions/ImguiSession.cpp
+++ b/shell/renderSessions/ImguiSession.cpp
@@ -28,12 +28,12 @@ void ImguiSession::update(igl::SurfaceTextures surfaceTextures) noexcept {
 
   auto cmdBuffer = _commandQueue->createCommandBuffer(igl::CommandBufferDesc(), nullptr);
 
-  igl::FramebufferDesc frambufferDesc;
-  frambufferDesc.colorAttachments[0].texture = surfaceTextures.color;
+  igl::FramebufferDesc framebufferDesc;
+  framebufferDesc.colorAttachments[0].texture = surfaceTextures.color;
   if (_outputFramebuffer) {
     _outputFramebuffer->updateDrawable(surfaceTextures.color);
   } else {
-    _outputFramebuffer = getPlatform().getDevice().createFramebuffer(frambufferDesc, nullptr);
+    _outputFramebuffer = getPlatform().getDevice().createFramebuffer(framebufferDesc, nullptr);
   }
 
   igl::RenderPassDesc renderPassDesc;
@@ -44,7 +44,7 @@ void ImguiSession::update(igl::SurfaceTextures surfaceTextures) noexcept {
   auto encoder = cmdBuffer->createRenderCommandEncoder(renderPassDesc, _outputFramebuffer);
 
   { // Draw using ImGui every frame
-    _imguiSession->beginFrame(frambufferDesc, getPlatform().getDisplayContext().scale);
+    _imguiSession->beginFrame(framebufferDesc, getPlatform().getDisplayContext().scale);
     ImGui::ShowDemoWindow();
     _imguiSession->endFrame(getPlatform().getDevice(), *encoder);
   }

--- a/shell/renderSessions/MRTSession.cpp
+++ b/shell/renderSessions/MRTSession.cpp
@@ -474,10 +474,10 @@ void MRTSession::createOrUpdateFramebufferDisplayLast(const igl::SurfaceTextures
   }
 
   // Framebuffer & Texture
-  FramebufferDesc frambufferDesc;
-  frambufferDesc.colorAttachments[0].texture = surfaceTextures.color;
+  FramebufferDesc framebufferDesc;
+  framebufferDesc.colorAttachments[0].texture = surfaceTextures.color;
 
-  framebufferDisplayLast_ = getPlatform().getDevice().createFramebuffer(frambufferDesc, nullptr);
+  framebufferDisplayLast_ = getPlatform().getDevice().createFramebuffer(framebufferDesc, nullptr);
 }
 
 void MRTSession::createOrUpdateFramebufferMRT(const igl::SurfaceTextures& surfaceTextures) {
@@ -492,12 +492,12 @@ void MRTSession::createOrUpdateFramebufferMRT(const igl::SurfaceTextures& surfac
     tex2_ = createTexture2D(surfaceTextures.color);
   }
   // Framebuffer & Texture
-  FramebufferDesc frambufferDesc;
+  FramebufferDesc framebufferDesc;
 
-  frambufferDesc.colorAttachments[0].texture = tex1_;
-  frambufferDesc.colorAttachments[1].texture = tex2_;
+  framebufferDesc.colorAttachments[0].texture = tex1_;
+  framebufferDesc.colorAttachments[1].texture = tex2_;
 
-  framebufferMRT_ = getPlatform().getDevice().createFramebuffer(frambufferDesc, nullptr);
+  framebufferMRT_ = getPlatform().getDevice().createFramebuffer(framebufferDesc, nullptr);
 }
 
 } // namespace shell

--- a/src/igl/Buffer.h
+++ b/src/igl/Buffer.h
@@ -123,7 +123,7 @@ class IBuffer : public ITrackedResource<IBuffer> {
   virtual Result upload(const void* IGL_NULLABLE data, const BufferRange& range) = 0;
 
   /**
-   * @brief Map a portion of the contents of a GPU Buffer into memory. Not efficient; intented
+   * @brief Map a portion of the contents of a GPU Buffer into memory. Not efficient; intended
    * primarily for debug and test use. unmap() must be called before the buffer is used again in any
    * GPU operations.
    *

--- a/src/igl/CommandQueue.h
+++ b/src/igl/CommandQueue.h
@@ -37,7 +37,7 @@ struct CommandQueueDesc {
 /**
  * Contains the current frame's draw count and last frame's draw count.
  * ICommandQueue controls these values and moves current draw count to last frame draw count through
- * the endFrame funcion.
+ * the endFrame function.
  */
 struct CommandQueueStatistics {
   uint32_t currentDrawCount = 0;

--- a/src/igl/DeviceFeatures.h
+++ b/src/igl/DeviceFeatures.h
@@ -109,7 +109,7 @@ enum class DeviceFeatures {
  * @brief DeviceRequirement denotes capturing specific requirements for a feature to be enabled.
  * These should be used in combination with DeviceFeatures to understand how to take advantage of
  * the feature.
- * For example, using the StandardDerivate feature with an OpenGL ES 2.0 device requires using an
+ * For example, using the StandardDerivative feature with an OpenGL ES 2.0 device requires using an
  * extension whereas it can be used without an extension for an OpenGL or OpenGL ES 3+ device.
  * If a device returns true for hasFeature(DeviceFeatures::ShaderTextureLod) and returns true for
  * hasRequirement(DeviceRequirement::ShaderTextureLodExtReq), then shader code wishing to use the

--- a/src/igl/RenderCommandEncoder.h
+++ b/src/igl/RenderCommandEncoder.h
@@ -49,7 +49,7 @@ class IRenderCommandEncoder : public ICommandEncoder {
   // Binds the buffer to a shader
   //
   // For metal, the index parameter is the buffer index specified in the shader, for opengl index
-  // referes to the location of uniform. The index value can be found by using
+  // refers to the location of uniform. The index value can be found by using
   // igl::RenderPipelineState::getIndexByName
   //
   // target is the igl::BindTarget type

--- a/src/igl/Texture.h
+++ b/src/igl/Texture.h
@@ -21,7 +21,7 @@ namespace igl {
  * texture. For example, TwoD corresponds to 2-dimensional textures.
  *
  *  Invalid          - Undefined,
- *  TwoD             - Single layer, two dimensonal: (Width, Height)
+ *  TwoD             - Single layer, two dimensional: (Width, Height)
  *  TwoDArray        - Multiple layers, two dimensional: (Width, Height)
  *  ThreeD           - 3 dimensional textures: (Width, Height, Depth)
  *  Cube             - Special case of 3 dimensional textures: (Width, Height, Depth), along with 6

--- a/src/igl/VertexInputState.h
+++ b/src/igl/VertexInputState.h
@@ -82,7 +82,7 @@ enum class VertexSampleFunction {
   PerVertex,
   Instance,
 
-  // Missing Tesselation support
+  // Missing Tessellation support
 };
 
 /**

--- a/src/igl/metal/BufferSynchronizationManager.mm
+++ b/src/igl/metal/BufferSynchronizationManager.mm
@@ -28,7 +28,7 @@ BufferSynchronizationManager::BufferSynchronizationManager(size_t maxInFlightBuf
 
 void BufferSynchronizationManager::markCommandBufferAsEndOfFrame(
     const igl::ICommandBuffer& commandBuffer) {
-  // Set a completetion handler for this cmd buffer
+  // Set a completion handler for this cmd buffer
   __weak dispatch_semaphore_t semaphore = frameBoundarySemaphore_;
   [static_cast<const CommandBuffer&>(commandBuffer).get()
       addCompletedHandler:^(id<MTLCommandBuffer> mtlCommandBuffer) {

--- a/src/igl/metal/CMakeLists.txt
+++ b/src/igl/metal/CMakeLists.txt
@@ -28,7 +28,7 @@ igl_set_cxxstd(IGLMetal 17)
 igl_set_folder(IGLMetal "IGL")
 
 set(OBJC_EXTRA_FLAGS -fobjc-arc -fobjc-weak)
-set(OBJC_DISABLE_WARNIGNS -Wno-objc-designated-initializers -Wno-objc-missing-super-calls -Wno-objc-property-no-attribute)
+set(OBJC_DISABLE_WARNINGS -Wno-objc-designated-initializers -Wno-objc-missing-super-calls -Wno-objc-property-no-attribute)
 
 if(CMAKE_GENERATOR MATCHES "Xcode")
   set_target_properties(IGLMetal PROPERTIES XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK YES)
@@ -38,6 +38,6 @@ else()
   target_compile_options(IGLMetal PRIVATE $<$<COMPILE_LANGUAGE:OBJCXX>:${OBJC_EXTRA_FLAGS}>)
 endif()
 
-target_compile_options(IGLMetal PRIVATE $<$<COMPILE_LANGUAGE:OBJC>:${OBJC_DISABLE_WARNIGNS}>)
-target_compile_options(IGLMetal PRIVATE $<$<COMPILE_LANGUAGE:OBJCXX>:${OBJC_DISABLE_WARNIGNS}>)
+target_compile_options(IGLMetal PRIVATE $<$<COMPILE_LANGUAGE:OBJC>:${OBJC_DISABLE_WARNINGS}>)
+target_compile_options(IGLMetal PRIVATE $<$<COMPILE_LANGUAGE:OBJCXX>:${OBJC_DISABLE_WARNINGS}>)
 target_compile_options(IGLMetal PRIVATE "-Wno-deprecated-declarations")

--- a/src/igl/opengl/RenderPipelineState.cpp
+++ b/src/igl/opengl/RenderPipelineState.cpp
@@ -257,7 +257,7 @@ void RenderPipelineState::unbind() {
 }
 
 // A buffer can be shared by multiple attributes. So bind all the attributes
-// asssociated with the associated buffer.
+// associated with the associated buffer.
 // bufferOffset is an offset in bytes to the start of the vertex attributes in the buffer.
 void RenderPipelineState::bindVertexAttributes(size_t bufferIndex, size_t bufferOffset) {
 #if IGL_DEBUG

--- a/src/igl/opengl/Texture.cpp
+++ b/src/igl/opengl/Texture.cpp
@@ -172,7 +172,7 @@ GLenum Texture::toGLTarget(TextureType type, size_t samples) const {
   return 0;
 }
 
-// Whenver possible the caller should have the incoming format in
+// Whenever possible the caller should have the incoming format in
 // igl::TextureFormat thus not use this function. For the cases when this
 // is not possible, e.g. dictated by a file header, then this function
 // can convert GL Texture format into IGL Texture Format

--- a/src/igl/opengl/UniformAdapter.cpp
+++ b/src/igl/opengl/UniformAdapter.cpp
@@ -19,8 +19,8 @@ UniformAdapter::UniformAdapter(const IContext& context, PipelineType type) : pip
 
   // NOTE: 32 "feels" right and yielded good results in MobileLab. Goal here is to minimize
   // number of resize's in the vector but not be unreasonably large.
-  constexpr size_t kLikelyMaxiumNumUniforms = 32;
-  uniforms_.reserve(kLikelyMaxiumNumUniforms);
+  constexpr size_t kLikelyMaximumNumUniforms = 32;
+  uniforms_.reserve(kLikelyMaximumNumUniforms);
 
   if (pipelineType_ == Render) {
     maxUniforms_ = deviceFeatures.getMaxVertexUniforms() + deviceFeatures.getMaxFragmentUniforms();

--- a/src/igl/opengl/UniformBuffer.h
+++ b/src/igl/opengl/UniformBuffer.h
@@ -46,7 +46,7 @@ class UniformBuffer final : public Buffer {
     return Type::Uniform;
   }
 
-  // For openGL, additional infomation required to bind the uniform is provided when the buffer is
+  // For openGL, additional information required to bind the uniform is provided when the buffer is
   // created within the igl::BufferDesc and igl::UniformBufferEntry (eg. offset, type, elementStride
   // and number of elements).
   //

--- a/src/igl/opengl/wgl/Context.h
+++ b/src/igl/opengl/wgl/Context.h
@@ -27,7 +27,7 @@ class Context : public IContext {
   Context(HDC deviceContext, HGLRC renderContext);
   /// Create a new context with existing HGLRC and share contexts the share context's
   /// must be setup ahead of calling this constructor. (eg. via QOpenGLContext->setShareContext) and
-  /// should not be modified during the existance of this IContext
+  /// should not be modified during the existence of this IContext
   Context(HDC deviceContext, HGLRC renderContext, std::vector<HGLRC> shareContexts);
 
   ~Context() override;

--- a/src/igl/tests/Backend.cpp
+++ b/src/igl/tests/Backend.cpp
@@ -71,10 +71,10 @@ class BackendTest : public ::testing::Test {
     ASSERT_TRUE(offscreenTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(framebuffer_ != nullptr);
 
@@ -172,7 +172,7 @@ class BackendTest : public ::testing::Test {
   std::shared_ptr<ITexture> offscreenTexture_;
   std::shared_ptr<IFramebuffer> framebuffer_;
 
-  // Currently it is left to individial tests to initialize this
+  // Currently it is left to individual tests to initialize this
   std::shared_ptr<ITexture> inputTexture_;
 
   std::shared_ptr<IShaderStages> shaderStages_;

--- a/src/igl/tests/Blending.cpp
+++ b/src/igl/tests/Blending.cpp
@@ -66,10 +66,10 @@ class BlendingTest : public ::testing::Test {
     ASSERT_TRUE(offscreenTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(framebuffer_ != nullptr);
 

--- a/src/igl/tests/ComputeCommandEncoder.cpp
+++ b/src/igl/tests/ComputeCommandEncoder.cpp
@@ -91,7 +91,7 @@ class ComputeCommandEncoderTest : public ::testing::Test {
   }
 
   /**
-   * @brief This function binds bufferIn and bufferOut to a new computePiplineState and encodes the
+   * @brief This function binds bufferIn and bufferOut to a new computePipelineState and encodes the
    * computePipelineState to a new computeCommandEncoder.
    */
   void encodeCompute(const std::shared_ptr<igl::ICommandBuffer>& cmdBuffer,

--- a/src/igl/tests/Device.cpp
+++ b/src/igl/tests/Device.cpp
@@ -52,10 +52,10 @@ class DeviceTest : public ::testing::Test {
     ASSERT_TRUE(offscreenTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(framebuffer_ != nullptr);
 

--- a/src/igl/tests/Framebuffer.cpp
+++ b/src/igl/tests/Framebuffer.cpp
@@ -268,7 +268,7 @@ TEST_F(FramebufferTest, Clear) {
   framebuffer_->copyBytesColorAttachment(*cmdQueue_, 0, pixels.data(), rangeDesc);
   ASSERT_EQ(pixels[0], 0x80808080);
 
-  // TODO: copyBytesDepthAttatchment is not functioning property under Metal
+  // TODO: copyBytesDepthAttachment is not functioning property under Metal
   // due to unimplemented blitting
   // Refer to igl/metal/Framebuffer.mm
   framebuffer_->copyBytesDepthAttachment(*cmdQueue_, pixels_depth.data(), rangeDesc);
@@ -319,7 +319,7 @@ TEST_F(FramebufferTest, Clear) {
   framebuffer_->copyBytesColorAttachment(*cmdQueue_, 0, pixels.data(), rangeDesc);
   ASSERT_EQ(pixels[0], 0);
 
-  // TODO: copyBytesDepthAttatchment is not functioning property under Metal
+  // TODO: copyBytesDepthAttachment is not functioning property under Metal
   // due to unimplemented blitting
   // Refer to igl/metal/Framebuffer.mm
   framebuffer_->copyBytesDepthAttachment(*cmdQueue_, pixels_depth.data(), rangeDesc);
@@ -404,10 +404,10 @@ TEST_F(FramebufferTest, blitFramebufferColor) {
     //-------------------------------------------------------------
     // Create second IFramebuffer framebuffer2 by offscreenTexture2
     //-------------------------------------------------------------
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture2;
-    std::shared_ptr<IFramebuffer> framebuffer2 = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture2;
+    std::shared_ptr<IFramebuffer> framebuffer2 = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_TRUE(ret.isOk());
     ASSERT_TRUE(framebuffer2 != nullptr);
 

--- a/src/igl/tests/ShaderLibrary.cpp
+++ b/src/igl/tests/ShaderLibrary.cpp
@@ -64,7 +64,7 @@ TEST_F(ShaderLibraryTest, CreateFromSource) {
   ASSERT_TRUE(vertShaderModule);
 }
 
-TEST_F(ShaderLibraryTest, CreateFromSoureReturnNullWithNullInput) {
+TEST_F(ShaderLibraryTest, CreateFromSourceReturnNullWithNullInput) {
   Result ret;
   if (!iglDev_->hasFeature(DeviceFeatures::ShaderLibrary)) {
     GTEST_SKIP() << "Shader Libraries are unsupported for this platform.";

--- a/src/igl/tests/Texture.cpp
+++ b/src/igl/tests/Texture.cpp
@@ -70,10 +70,10 @@ class TextureTest : public ::testing::Test {
     ASSERT_TRUE(offscreenTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(framebuffer_ != nullptr);
 
@@ -172,7 +172,7 @@ class TextureTest : public ::testing::Test {
   std::shared_ptr<ITexture> offscreenTexture_;
   std::shared_ptr<IFramebuffer> framebuffer_;
 
-  // Currently it is left to individial tests to initialize this
+  // Currently it is left to individual tests to initialize this
   std::shared_ptr<ITexture> inputTexture_;
 
   std::shared_ptr<IShaderStages> shaderStages_;
@@ -548,7 +548,7 @@ TEST_F(TextureTest, PassthroughSubTexture) {
 // This test will exercise the copy functionality via the following steps:
 //   1. clear FB to (0.5, 0.5, 0.5, 0.5)
 //   2. Copy content to a texture
-//   3. clear FB to (0, 0, 0, 0) and verfy it is cleared
+//   3. clear FB to (0, 0, 0, 0) and verify it is cleared
 //   4. Copy texture content to FB
 //   5. Verify that the FB is back to (0.5, 0.5, 0.5, 0.5)
 //
@@ -703,9 +703,9 @@ TEST_F(TextureTest, PIXEL_UPLOAD_ALIGNMENT) {
   ASSERT_EQ(ret.code, Result::Code::Ok);
   ASSERT_TRUE(customOffscreenTexture != nullptr);
 
-  FramebufferDesc frambufferDesc;
-  frambufferDesc.colorAttachments[0].texture = customOffscreenTexture;
-  auto customFramebuffer = iglDev_->createFramebuffer(frambufferDesc, &ret);
+  FramebufferDesc framebufferDesc;
+  framebufferDesc.colorAttachments[0].texture = customOffscreenTexture;
+  auto customFramebuffer = iglDev_->createFramebuffer(framebufferDesc, &ret);
   ASSERT_EQ(ret.code, Result::Code::Ok);
   ASSERT_TRUE(customFramebuffer != nullptr);
 
@@ -863,10 +863,10 @@ TEST_F(TextureTest, Resize) {
   ASSERT_TRUE(outputTex != nullptr);
 
   // Create framebuffer using the output texture
-  FramebufferDesc frambufferDesc;
+  FramebufferDesc framebufferDesc;
 
-  frambufferDesc.colorAttachments[0].texture = outputTex;
-  auto fb = iglDev_->createFramebuffer(frambufferDesc, &ret);
+  framebufferDesc.colorAttachments[0].texture = outputTex;
+  auto fb = iglDev_->createFramebuffer(framebufferDesc, &ret);
   ASSERT_EQ(ret.code, Result::Code::Ok);
   ASSERT_TRUE(fb != nullptr);
 

--- a/src/igl/tests/TextureArray.cpp
+++ b/src/igl/tests/TextureArray.cpp
@@ -104,10 +104,10 @@ class TextureArrayTest : public ::testing::Test {
     ASSERT_TRUE(offscreenTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(framebuffer_ != nullptr);
 
@@ -253,7 +253,7 @@ class TextureArrayTest : public ::testing::Test {
   std::shared_ptr<ITexture> offscreenTexture_;
   std::shared_ptr<IFramebuffer> framebuffer_;
 
-  // Currently it is left to individial tests to initialize this
+  // Currently it is left to individual tests to initialize this
   std::shared_ptr<ITexture> inputTexture_;
 
   std::shared_ptr<IShaderStages> shaderStages_;

--- a/src/igl/tests/TextureCube.cpp
+++ b/src/igl/tests/TextureCube.cpp
@@ -93,10 +93,10 @@ class TextureCubeTest : public ::testing::Test {
     ASSERT_TRUE(offscreenTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(framebuffer_ != nullptr);
 
@@ -202,7 +202,7 @@ class TextureCubeTest : public ::testing::Test {
   std::shared_ptr<ITexture> offscreenTexture_;
   std::shared_ptr<IFramebuffer> framebuffer_;
 
-  // Currently it is left to individial tests to initialize this
+  // Currently it is left to individual tests to initialize this
   std::shared_ptr<ITexture> inputTexture_;
 
   std::shared_ptr<IShaderStages> shaderStages_;

--- a/src/igl/tests/metal/Texture.mm
+++ b/src/igl/tests/metal/Texture.mm
@@ -121,7 +121,7 @@ TEST_F(TextureMTLTest, GetMipmapsCount) {
 
 // Test conversion from MTLTextureType to IGL TextureType
 TEST_F(TextureMTLTest, ToTextureType) {
-  std::vector<std::pair<MTLTextureType, TextureType>> inputAndExpectdList = {
+  std::vector<std::pair<MTLTextureType, TextureType>> inputAndExpectedList = {
       std::make_pair(MTLTextureType2D, TextureType::TwoD),
       std::make_pair(MTLTextureType2DMultisample, TextureType::TwoD),
       std::make_pair(MTLTextureType2DArray, TextureType::TwoDArray),
@@ -130,12 +130,12 @@ TEST_F(TextureMTLTest, ToTextureType) {
       std::make_pair(MTLTextureTypeCubeArray, TextureType::Invalid),
   };
   if (@available(macOS 10.14, iOS 14.0, *)) {
-    inputAndExpectdList.emplace_back(MTLTextureType2DMultisampleArray, TextureType::TwoDArray);
+    inputAndExpectedList.emplace_back(MTLTextureType2DMultisampleArray, TextureType::TwoDArray);
   }
 
-  for (auto inputAndExpectd : inputAndExpectdList) {
-    auto input = inputAndExpectd.first;
-    auto expected = inputAndExpectd.second;
+  for (auto inputAndExpected : inputAndExpectedList) {
+    auto input = inputAndExpected.first;
+    auto expected = inputAndExpected.second;
     auto result = igl::metal::Texture::convertType(input);
     ASSERT_EQ(expected, result);
   }
@@ -145,7 +145,7 @@ TEST_F(TextureMTLTest, ToTextureType) {
 // Current IGL makes the following assumptions, which may not be valid in the future
 //   * Falls back to MTLTextureType1D for TextureType::Invalid
 TEST_F(TextureMTLTest, ToMTLTextureType) {
-  std::vector<std::tuple<TextureType, size_t, MTLTextureType>> inputAndExpectdList = {
+  std::vector<std::tuple<TextureType, size_t, MTLTextureType>> inputAndExpectedList = {
       std::make_tuple(TextureType::Invalid, 1, MTLTextureType1D),
       std::make_tuple(TextureType::TwoD, 1, MTLTextureType2D),
       std::make_tuple(TextureType::TwoD, 2, MTLTextureType2DMultisample),
@@ -153,13 +153,13 @@ TEST_F(TextureMTLTest, ToMTLTextureType) {
       std::make_tuple(TextureType::ThreeD, 1, MTLTextureType3D),
       std::make_tuple(TextureType::Cube, 1, MTLTextureTypeCube)};
   if (@available(macOS 10.14, iOS 14.0, *)) {
-    inputAndExpectdList.emplace_back(TextureType::TwoDArray, 2, MTLTextureType2DMultisampleArray);
+    inputAndExpectedList.emplace_back(TextureType::TwoDArray, 2, MTLTextureType2DMultisampleArray);
   }
 
-  for (auto inputAndExpectd : inputAndExpectdList) {
-    auto input = std::get<0>(inputAndExpectd);
-    auto numSamples = std::get<1>(inputAndExpectd);
-    auto expected = std::get<2>(inputAndExpectd);
+  for (auto inputAndExpected : inputAndExpectedList) {
+    auto input = std::get<0>(inputAndExpected);
+    auto numSamples = std::get<1>(inputAndExpected);
+    auto expected = std::get<2>(inputAndExpected);
     auto result = igl::metal::Texture::convertType(input, numSamples);
     ASSERT_EQ(expected, result);
   }

--- a/src/igl/tests/ogl/DepthStencilState.cpp
+++ b/src/igl/tests/ogl/DepthStencilState.cpp
@@ -58,10 +58,10 @@ class DepthStencilStateTest : public ::testing::Test {
     ASSERT_TRUE(offscreenTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(framebuffer_ != nullptr);
 

--- a/src/igl/tests/ogl/Device.cpp
+++ b/src/igl/tests/ogl/Device.cpp
@@ -76,7 +76,7 @@ TEST_F(DeviceOGLTest, EndScope) {
     DeviceScope deviceScope(*iglDev_);
     ASSERT_TRUE(iglDev_->verifyScope());
 
-    // Artifically set values that will be restored when endScope is called
+    // Artificially set values that will be restored when endScope is called
     context_->colorMask(false, false, false, false);
     context_->blendFunc(GL_SRC_COLOR, GL_DST_COLOR);
 
@@ -231,9 +231,9 @@ TEST_F(DeviceOGLTest, DeletionTest) {
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(texture != nullptr);
 
-    FramebufferDesc frambufferDesc;
-    frambufferDesc.colorAttachments[0].texture = texture;
-    framebuffer = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    FramebufferDesc framebufferDesc;
+    framebufferDesc.colorAttachments[0].texture = texture;
+    framebuffer = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(framebuffer != nullptr);
 

--- a/src/igl/tests/ogl/PipelineState.cpp
+++ b/src/igl/tests/ogl/PipelineState.cpp
@@ -65,10 +65,10 @@ class PipelineStateOGLTest : public ::testing::Test {
     ASSERT_TRUE(offscreenTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_TRUE(ret.isOk());
     ASSERT_TRUE(framebuffer_ != nullptr);
 

--- a/src/igl/tests/ogl/SamplerState.cpp
+++ b/src/igl/tests/ogl/SamplerState.cpp
@@ -55,7 +55,7 @@ class SamplerStateOGLTest : public ::testing::Test {
 //
 // convertGLMinFilter tests
 //
-// This tests convertions from glMinFilter to
+// This tests conversions from glMinFilter to
 // SamplerMinMagFilter
 //
 TEST_F(SamplerStateOGLTest, SamplerStateConvertGLMinFilter) {

--- a/src/igl/tests/ogl/UniformBuffer.cpp
+++ b/src/igl/tests/ogl/UniformBuffer.cpp
@@ -416,10 +416,10 @@ class UniformBufferTest : public ::testing::Test {
     ASSERT_TRUE(inputTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_TRUE(ret.isOk());
     ASSERT_TRUE(framebuffer_ != nullptr);
 

--- a/src/igl/tests/sRGB.cpp
+++ b/src/igl/tests/sRGB.cpp
@@ -70,10 +70,10 @@ class sRGBTest : public ::testing::Test {
     ASSERT_TRUE(offscreenTexture_ != nullptr);
 
     // Create framebuffer using the offscreen texture
-    FramebufferDesc frambufferDesc;
+    FramebufferDesc framebufferDesc;
 
-    frambufferDesc.colorAttachments[0].texture = offscreenTexture_;
-    framebuffer_ = iglDev_->createFramebuffer(frambufferDesc, &ret);
+    framebufferDesc.colorAttachments[0].texture = offscreenTexture_;
+    framebuffer_ = iglDev_->createFramebuffer(framebufferDesc, &ret);
     ASSERT_EQ(ret.code, Result::Code::Ok);
     ASSERT_TRUE(framebuffer_ != nullptr);
 
@@ -172,7 +172,7 @@ class sRGBTest : public ::testing::Test {
   std::shared_ptr<ITexture> offscreenTexture_;
   std::shared_ptr<IFramebuffer> framebuffer_;
 
-  // Currently it is left to individial tests to initialize this
+  // Currently it is left to individual tests to initialize this
   std::shared_ptr<ITexture> inputTexture_;
 
   std::shared_ptr<IShaderStages> shaderStages_;

--- a/src/igl/vulkan/EnhancedShaderDebuggingStore.h
+++ b/src/igl/vulkan/EnhancedShaderDebuggingStore.h
@@ -79,7 +79,7 @@ class EnhancedShaderDebuggingStore {
   /** @brief Returns the shader code that stores the line vertices in the buffer. This code can be
    * injected into all shaders compiled by the device.
    * @param[in] includeFunctionBody a flag that determines if the returned code should include the
-   * funtion's code in the body of the function. If false the function returns a function with an
+   * function's code in the body of the function. If false the function returns a function with an
    * empty body
    * @param[in] extensions the extensions available for the device.
    */

--- a/src/igl/vulkan/HWDevice.h
+++ b/src/igl/vulkan/HWDevice.h
@@ -35,7 +35,7 @@ class HWDevice final {
   /*
    * @brief Create a new vulkan::Device
    *        Only 1 device can be created for Vulkan. The new device will take ownership of
-   * VulkanContext. If the process failes, the provided VulkanContext is destroyed.
+   * VulkanContext. If the process fails, the provided VulkanContext is destroyed.
    */
 
   static std::unique_ptr<IDevice> create(std::unique_ptr<VulkanContext> ctx,

--- a/src/igl/vulkan/RenderPipelineState.cpp
+++ b/src/igl/vulkan/RenderPipelineState.cpp
@@ -335,12 +335,12 @@ VkPipeline RenderPipelineState::getVkPipeline(
                        dynamicState.getStencilStateFailOp(true),
                        dynamicState.getStencilStatePassOp(true),
                        dynamicState.getStencilStateDepthFailOp(true),
-                       dynamicState.getStencilStateComapreOp(true))
+                       dynamicState.getStencilStateCompareOp(true))
       .stencilStateOps(VK_STENCIL_FACE_BACK_BIT,
                        dynamicState.getStencilStateFailOp(false),
                        dynamicState.getStencilStatePassOp(false),
                        dynamicState.getStencilStateDepthFailOp(false),
-                       dynamicState.getStencilStateComapreOp(false))
+                       dynamicState.getStencilStateCompareOp(false))
       .shaderStages({
           ivkGetPipelineShaderStageCreateInfo(
               VK_SHADER_STAGE_VERTEX_BIT,

--- a/src/igl/vulkan/RenderPipelineState.h
+++ b/src/igl/vulkan/RenderPipelineState.h
@@ -107,7 +107,7 @@ class alignas(sizeof(uint64_t)) RenderPipelineDynamicState {
     return static_cast<VkStencilOp>(front ? stencilFrontDepthFailOp_ : stencilBackDepthFailOp_);
   }
 
-  VkCompareOp getStencilStateComapreOp(bool front) const {
+  VkCompareOp getStencilStateCompareOp(bool front) const {
     return static_cast<VkCompareOp>(front ? stencilFrontCompareOp_ : stencilBackCompareOp_);
   }
 

--- a/src/igl/vulkan/VulkanContext.cpp
+++ b/src/igl/vulkan/VulkanContext.cpp
@@ -1270,7 +1270,7 @@ void VulkanContext::DynamicUniformsBufferSet::markSubmit(
     DUBs_[lastSubmittedDUBIndex_].handle_ = handle;
   }
 
-  // force a move to the next DUB in `udpateDynamicUniforms` - acquire here so that multiple
+  // force a move to the next DUB in `updateDynamicUniforms` - acquire here so that multiple
   // sequential calls to markSubmit() work as expected
   acquireNextDUB();
 }

--- a/src/igl/vulkan/VulkanQueuePool.h
+++ b/src/igl/vulkan/VulkanQueuePool.h
@@ -25,7 +25,7 @@ struct VulkanQueueDescriptor {
     return queueIndex != INVALID && familyIndex != INVALID;
   }
 
-  /* familyIndex and queueIndex are sufficent to uniquely identify a VulkanQueueDescriptor. */
+  /* familyIndex and queueIndex are sufficient to uniquely identify a VulkanQueueDescriptor. */
   bool operator==(const VulkanQueueDescriptor& other) const {
     return (familyIndex == other.familyIndex && queueIndex == other.queueIndex);
   }


### PR DESCRIPTION
This revision includes:
- Fix many typos
  - sufficent -> sufficient
  - udpate -> update
  - Comapre -> Compare
  - failes -> fails
  - funcion/funtion -> function
  - Tesselation -> Tessellation
  - dimensonal -> dimensional
  - frambuffer -> framebuffer
  - individial -> individual
  - verfy -> verify
  - Soure -> Source
  - convertions -> conversions
  - Artifically -> Artificially
  - Expectd -> Expected
  - Attatchment -> Attachment
  - Pipline -> Pipeline
  - referes -> refers
  - existance -> existence
  - infomation -> information
  - Maxium -> Maximum
  - Whenver -> Whenever
  - asssociated -> associated
  - WARNIGNS -> WARNINGS
  - completetion -> completion
  - Derivate -> Derivative
  - intented -> intended
  - intialized -> initialized
  - decriptor -> descriptor
  - uesd -> used
  - relavent -> relevant
  - platfrom -> platform