### PR TITLE
Fix nullable-to-nonnull-conversion warnings

### DIFF
--- a/src/igl/metal/Texture.h
+++ b/src/igl/metal/Texture.h
@@ -51,10 +51,10 @@ class Texture final : public ITexture {
   bool isRequiredGenerateMipmap() const override;
   uint64_t getTextureId() const override;
 
-  IGL_INLINE id<MTLTexture> get() const {
+  IGL_INLINE id<MTLTexture> _Nullable get() const {
     return (drawable_) ? drawable_.texture : value_;
   }
-  IGL_INLINE id<CAMetalDrawable> getDrawable() const {
+  IGL_INLINE id<CAMetalDrawable> _Nullable getDrawable() const {
     return drawable_;
   }
 


### PR DESCRIPTION
Summary:
Cleaning up some build warnings when Wnullable-to-nonnull-conversion is enabled.

Changelog: Fixes nullability warnings from `Texture.h`.

Differential Revision: D47886354

