### PR TITLE
Expose MTLTexture > ITexture conversion in igl/metal/PlatformDevice.h

### DIFF
--- a/src/igl/metal/PlatformDevice.h
+++ b/src/igl/metal/PlatformDevice.h
@@ -47,6 +47,13 @@ class PlatformDevice final : public IPlatformDevice {
   std::unique_ptr<ITexture> createTextureFromNativeDrawable(id<CAMetalDrawable> nativeDrawable,
                                                             Result* outResult);
 
+  /// Creates a texture from a native drawable
+  /// @param nativeDrawable drawable. For Metal is MUST be MTLTexture
+  /// @param outResult optional result
+  /// @return pointer to generated Texture or nullptr
+  std::unique_ptr<ITexture> createTextureFromNativeDrawable(id<MTLTexture> nativeDrawable,
+                                                            Result* outResult);
+
   /// Creates a texture from a native drawable surface
   /// @param nativeDrawable drawable surface. For Metal is MUST be CAMetalLayer
   /// @param outResult optional result

--- a/src/igl/metal/PlatformDevice.mm
+++ b/src/igl/metal/PlatformDevice.mm
@@ -73,6 +73,17 @@ std::unique_ptr<ITexture> PlatformDevice::createTextureFromNativeDrawable(
   return iglObject;
 }
 
+std::unique_ptr<ITexture> PlatformDevice::createTextureFromNativeDrawable(
+    id<MTLTexture> nativeDrawable,
+    Result* outResult) {
+  auto iglObject = std::make_unique<Texture>(nativeDrawable);
+  if (auto resourceTracker = device_.getResourceTracker()) {
+    iglObject->initResourceTracker(resourceTracker);
+  }
+  Result::setOk(outResult);
+  return iglObject;
+}
+
 std::unique_ptr<ITexture> PlatformDevice::createTextureFromNativeDrawable(CALayer* nativeDrawable,
                                                                           Result* outResult) {
   if (!nativeDrawable) {


### PR DESCRIPTION
Summary: This exposes the `Texture` constructor taking a `MTLTexture` instance.

Reviewed By: MichaelTay

Differential Revision: D47894725

