### PR TITLE
Fix macOS sample crashing on loading image resource

### DIFF
--- a/shell/mac/CMakeLists.txt
+++ b/shell/mac/CMakeLists.txt
@@ -35,9 +35,10 @@ function(ADD_SHELL_SESSION_WITH_SRCS target srcs libs)
   file(GLOB SHELL_SESSION_SRC_FILES LIST_DIRECTORIES false ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/*.mm
                                                            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/*.m)
   file(GLOB SHELL_SESSION_HEADER_FILES LIST_DIRECTORIES false ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/*.h)
+  file(GLOB RESOURCES LIST_DIRECTORIES false ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../resources/images/*.png)
 
   add_executable(${target} MACOSX_BUNDLE ${srcs} "${SHELL_SESSION_SRC_FILES}" "${SHELL_SESSION_SHELL_HEADER_FILES}"
-                                         "${XIBFILE}")
+                                         "${XIBFILE}" "${RESOURCES}")
   igl_set_folder(${target} "IGL Shell Sessions")
   igl_set_cxxstd(${target} 17)
   target_compile_definitions(${target} PRIVATE "IGL_SHELL_SESSION=${target}")
@@ -61,4 +62,5 @@ function(ADD_SHELL_SESSION_WITH_SRCS target srcs libs)
     ${target} PUBLIC "-framework AVFoundation" "-framework CoreGraphics" "-framework CoreMotion" "-framework AppKit"
                      "-framework Metal" "-framework MetalKit" "-framework OpenGL" "-framework QuartzCore")
   set_target_properties(${target} PROPERTIES MACOSX_BUNDLE TRUE RESOURCE "${XIBFILE}")
+  set_source_files_properties(${RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 endfunction()


### PR DESCRIPTION
Building `ColorSession` on macOS:
```sh
cmake -DIGL_WITH_VULKAN=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 -DCMAKE_OSX_ARCHITECTURES=x86_64  -Bbuild -G Ninja
cmake --build build --config Debug --target ColorSession
```
Running  `ColorSession`
```
./build/shell/ColorSession.app/Contents/MacOS/ColorSession
```
... and it crashes:
```
[IGL] Assert failed in 'virtual igl::shell::ImageData igl::shell::ImageLoaderMac::loadImageData(std::string)' (~/igl/shell/shared/imageLoader/mac/ImageLoaderMac.mm:40): Could not find image file: macbeth.png
[1]    94725 trace trap 
```
The images loaded via `NSBundle` API (in ImageLoaderMac.mm) should be bundled in `.app` .