### PR TITLE
Make screenshot taking helper public

### DIFF
--- a/shell/shared/renderSession/ScreenshotTestRenderSessionHelper.cpp
+++ b/shell/shared/renderSession/ScreenshotTestRenderSessionHelper.cpp
@@ -13,7 +13,7 @@
 #include <shell/shared/renderSession/ShellParams.h>
 
 namespace igl::shell {
-namespace {
+
 void SaveFrameBufferToPng(const char* absoluteFilename,
                           const std::shared_ptr<IFramebuffer>& framebuffer,
                           Platform& platform) {
@@ -37,7 +37,6 @@ void SaveFrameBufferToPng(const char* absoluteFilename,
   IGLLog(IGLLogLevel::LOG_INFO, "Writing screenshot to: %s", absoluteFilename);
   platform.getImageWriter().writeImage(absoluteFilename, imageData);
 }
-} // namespace
 
 void ScreenshotTestRenderSessionHelper::initialize(AppParams& appParams) noexcept {
   const char* screenshotTestsOutPath = std::getenv("SCREENSHOT_TESTS_OUT");

--- a/shell/shared/renderSession/ScreenshotTestRenderSessionHelper.h
+++ b/shell/shared/renderSession/ScreenshotTestRenderSessionHelper.h
@@ -13,6 +13,7 @@
 
 namespace igl {
 class ITexture;
+class IFramebuffer;
 } // namespace igl
 
 namespace igl::shell {
@@ -33,5 +34,9 @@ class ScreenshotTestRenderSessionHelper {
  private:
   int frameTicked_ = 0;
 };
+
+void SaveFrameBufferToPng(const char* absoluteFilename,
+                          const std::shared_ptr<IFramebuffer>& framebuffer,
+                          Platform& platform);
 
 } // namespace igl::shell


### PR DESCRIPTION
Summary:
This is something that we would like to reuse for our own screenshot tests in the ReactNative/Granite/IGL implementation (see the next diff in the stack).

The method was internal, this diffs makes it usable from outside.

Differential Revision: D48864515

