### PR TITLE
PlatformIos > Pass device as shared_ptr

### DIFF
--- a/shell/shared/platform/ios/PlatformIos.h
+++ b/shell/shared/platform/ios/PlatformIos.h
@@ -17,7 +17,7 @@ namespace igl::shell {
 class PlatformIos : public Platform {
  public:
   ~PlatformIos() override = default;
-  PlatformIos(std::unique_ptr<igl::IDevice> device);
+  PlatformIos(std::shared_ptr<igl::IDevice> device);
   igl::IDevice& getDevice() noexcept override;
   std::shared_ptr<igl::IDevice> getDevicePtr() const noexcept override;
   ImageLoader& getImageLoader() noexcept override;

--- a/shell/shared/platform/ios/PlatformIos.mm
+++ b/shell/shared/platform/ios/PlatformIos.mm
@@ -13,7 +13,7 @@
 
 namespace igl::shell {
 
-PlatformIos::PlatformIos(std::unique_ptr<igl::IDevice> device) : device_(std::move(device)) {
+PlatformIos::PlatformIos(std::shared_ptr<igl::IDevice> device) : device_(std::move(device)) {
   fileLoader_ = std::make_unique<igl::shell::FileLoaderApple>();
   imageLoader_ = std::make_unique<igl::shell::ImageLoader>(*fileLoader_);
   imageWriter_ = std::make_unique<igl::shell::ImageWriterIos>();


### PR DESCRIPTION
Summary:
The constructor takes a `unique_ptr` - but internally stores it as a `shared_ptr` anymore.

https://github.com/facebook/igl/blob/main/shell/shared/platform/ios/PlatformIos.h#L28C17-L28C17

This change aligns the iOS implementation with the macOS one:
https://github.com/facebook/igl/blob/main/shell/shared/platform/mac/PlatformMac.h#L16

Differential Revision: D52787496


