### PR TITLE
Fix cmake shell builds not installing successfully on an iOS device

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cmake .. -G "Xcode" -DIGL_WITH_VULKAN=OFF
 
 ```
 cd build
-cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../third-party/deps/src/ios-cmake/ios.toolchain.cmake -DPLATFORM=SIMULATOR64
+cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../third-party/deps/src/ios-cmake/ios.toolchain.cmake -DDEPLOYMENT_TARGET=13.0 -DPLATFORM=OS64
 ```
 
 * Android

--- a/shell/ios/CMakeLists.txt
+++ b/shell/ios/CMakeLists.txt
@@ -51,6 +51,13 @@ function(ADD_SHELL_SESSION_WITH_SRCS target srcs libs)
            "-framework QuartzCore"
            "-framework UIKit")
   set_target_properties(
-    ${target} PROPERTIES MACOSX_BUNDLE TRUE MACOSX_BUNDLE_GUI_IDENTIFIER "com.meta.iglshell" MACOSX_BUNDLE_BUNDLE_VERSION "1.0.0"
-                         MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0.0" RESOURCE "${RESOURCES}")
+    ${target}
+    PROPERTIES
+      MACOSX_BUNDLE TRUE
+      MACOSX_BUNDLE_BUNDLE_NAME "${target}"
+      MACOSX_BUNDLE_GUI_IDENTIFIER "com.meta.${target}"
+      MACOSX_BUNDLE_BUNDLE_VERSION "1.0.0"
+      MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0.0"
+      RESOURCE "${RESOURCES}"
+  )
 endfunction()


### PR DESCRIPTION
Build was successful, but installing failed with "Failure Reason: Failed to get the localized bundle name for the app to be installed. Recovery Suggestion: Ensure that your bundle's Info.plist contains a value for at least one of the following keys: CFBundleName or CFBundleDisplayName."

In this commit, I'm setting the CFBundleName and also using the shell session name as the identifier, so multiple shell apps can be installed on the same device without collision.

Test steps:
1. $ mkdir build & cd build
2. $ cmake .. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../third-party/igl/third-party/deps/src/ios-cmake/ios.toolchain.cmake -DDEPLOYMENT_TARGET=14.0 -DPLATFORM=OS64 -DENABLE_BITCODE=OFF
3. Open and build any shell apps in the generated Xcode project. You may have to manually set the Development Team.
4. Verify the apps now run as expected.