### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/build/android/app/src/main/java/com/facebook/igl/sample/SampleLib.java
+++ b/build/android/app/src/main/java/com/facebook/igl/sample/SampleLib.java
@@ -16,6 +16,7 @@ public class SampleLib {
   static {
     System.loadLibrary("ColorSession");
   }
+
   // should match with IDs in TinyRenderer.h
   protected static final int gl3ID = 0;
   protected static final int gl2ID = 1;

--- a/shell/android/java/com/facebook/igl/sample/SampleLib.java
+++ b/shell/android/java/com/facebook/igl/sample/SampleLib.java
@@ -16,6 +16,7 @@ public class SampleLib {
   static {
     System.loadLibrary("sampleJni");
   }
+
   // should match with IDs in TinyRenderer.h
   protected static final int gl3ID = 0;
   protected static final int gl2ID = 1;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


