### PR TITLE
WASM build step in the github action script

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -107,12 +107,18 @@ jobs:
           with:
             submodules: recursive
 
-        - if: startsWith(matrix.config.os, 'ubuntu')
+        - if: startsWith(matrix.config.name, 'Ubuntu - Emscripten')
           run: |
             sudo sed -i 's/azure\.//' /etc/apt/sources.list
             sudo apt-get update
             sudo apt-get install -y clang emscripten xorg-dev libxinerama-dev libxcursor-dev libgles2-mesa-dev libegl1-mesa-dev libglfw3-dev libglew-dev libstdc++-12-dev
-
+        
+        - if: startsWith(matrix.config.name, 'Ubuntu - Clang' ) || startsWith(matrix.config.name, 'Ubuntu - GCC')
+          run: |
+            sudo sed -i 's/azure\.//' /etc/apt/sources.list
+            sudo apt-get update
+            sudo apt-get install -y clang xorg-dev libxinerama-dev libxcursor-dev libgles2-mesa-dev libegl1-mesa-dev libglfw3-dev libglew-dev libstdc++-12-dev
+        
         - name: Prepare Vulkan SDK
           uses: humbletim/setup-vulkan-sdk@v1.2.0
           with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -134,7 +134,7 @@ jobs:
           env:
             CC:  ${{ matrix.config.cc }}
             CXX: ${{ matrix.config.cxx }}
-          if: ${{ !matrix.config.name  == 'Ubuntu - Emscripten' }}
+          if: ${{ matrix.config.name  != 'Ubuntu - Emscripten' }}
           run: |
               cmake ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build ${{ matrix.config.cmake_args }}
               cd build

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -128,14 +128,19 @@ jobs:
           env:
             CC:  ${{ matrix.config.cc }}
             CXX: ${{ matrix.config.cxx }}
+          if: ${{ !matrix.config.name  == 'Ubuntu - Emscripten' }}
           run: |
-            if [[ "${{ matrix.config.name }}" == "Ubuntu - Emscripten" ]]; then
+              cmake ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build ${{ matrix.config.cmake_args }}
+              cd build
+              cmake --build . --parallel ${{ steps.cpu-cores.outputs.count }}
+
+        - name: Build Emscripten
+          shell: bash
+          env:
+            CC:  ${{ matrix.config.cc }}
+            CXX: ${{ matrix.config.cxx }}
+          if: ${{ matrix.config.name  == 'Ubuntu - Emscripten' }}
+          run: |
               emcmake cmake ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build ${{ matrix.config.cmake_args }}
               cd build
               cmake --build . --parallel ${{ steps.cpu-cores.outputs.count }}
-            else
-              make ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build ${{ matrix.config.cmake_args }}
-              cd build
-              cmake --build . --parallel ${{ steps.cpu-cores.outputs.count }}
-            fi
-

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -75,6 +75,14 @@ jobs:
               cmake_args: "-DIGL_WITH_TRACY=ON -DIGL_WITH_SHELL=OFF"
             }
           - {
+              name: "Ubuntu - Emscripten",
+              os: ubuntu-latest,
+              build_type: "Debug",
+              cc: "emcc",
+              cxx: "em++",
+              generators: "Ninja",
+          }
+          - {
               name: "macOS - Clang (Xcode)",
               os: macos-latest,
               build_type: "Debug",
@@ -103,7 +111,7 @@ jobs:
           run: |
             sudo sed -i 's/azure\.//' /etc/apt/sources.list
             sudo apt-get update
-            sudo apt-get install -y clang xorg-dev libxinerama-dev libxcursor-dev libgles2-mesa-dev libegl1-mesa-dev libglfw3-dev libglew-dev libstdc++-12-dev
+            sudo apt-get install -y clang emscripten xorg-dev libxinerama-dev libxcursor-dev libgles2-mesa-dev libegl1-mesa-dev libglfw3-dev libglew-dev libstdc++-12-dev
 
         - name: Prepare Vulkan SDK
           uses: humbletim/setup-vulkan-sdk@v1.2.0

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -129,6 +129,13 @@ jobs:
             CC:  ${{ matrix.config.cc }}
             CXX: ${{ matrix.config.cxx }}
           run: |
-            cmake ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build ${{ matrix.config.cmake_args }}
-            cd build
-            cmake --build . --parallel ${{ steps.cpu-cores.outputs.count }}
+            if [[ "${{ matrix.config.name }}" == "Ubuntu - Emscripten" ]]; then
+              emcmake cmake ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build ${{ matrix.config.cmake_args }}
+              cd build
+              cmake --build . --parallel ${{ steps.cpu-cores.outputs.count }}
+            else
+              make ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build ${{ matrix.config.cmake_args }}
+              cd build
+              cmake --build . --parallel ${{ steps.cpu-cores.outputs.count }}
+            fi
+

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Android (Ubuntu)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -103,7 +103,7 @@ jobs:
       runs-on: ${{ matrix.config.os }}
 
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
             submodules: recursive
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -75,7 +75,7 @@ jobs:
               cmake_args: "-DIGL_WITH_TRACY=ON -DIGL_WITH_SHELL=OFF"
             }
           - {
-              name: "Ubuntu - Emscripten",
+              name: "Emscripten (Ubuntu)",
               os: ubuntu-latest,
               build_type: "Debug",
               cc: "emcc",
@@ -107,7 +107,7 @@ jobs:
           with:
             submodules: recursive
 
-        - if: startsWith(matrix.config.name, 'Ubuntu - Emscripten')
+        - if: startsWith(matrix.config.name, 'Emscripten (Ubuntu)')
           run: |
             sudo sed -i 's/azure\.//' /etc/apt/sources.list
             sudo apt-get update
@@ -134,7 +134,7 @@ jobs:
           env:
             CC:  ${{ matrix.config.cc }}
             CXX: ${{ matrix.config.cxx }}
-          if: ${{ matrix.config.name  != 'Ubuntu - Emscripten' }}
+          if: ${{ matrix.config.name  != 'Emscripten (Ubuntu)' }}
           run: |
               cmake ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build ${{ matrix.config.cmake_args }}
               cd build
@@ -145,7 +145,7 @@ jobs:
           env:
             CC:  ${{ matrix.config.cc }}
             CXX: ${{ matrix.config.cxx }}
-          if: ${{ matrix.config.name  == 'Ubuntu - Emscripten' }}
+          if: ${{ matrix.config.name  == 'Emscripten (Ubuntu)' }}
           run: |
               emcmake cmake ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build ${{ matrix.config.cmake_args }}
               cd build


### PR DESCRIPTION
# WASM build step in the github action script
This PR add a build step script to the github action workflows as mentioned in issue #67. It also partially try to solve issue #71.
The build process is implemented in the Ubuntu OS, the Emscripten environnment is installed with the `apt` package manager, but it could be possible instead to run with docker and choose which [emsdk](https://hub.docker.com/r/emscripten/emsdk) version to use.

