### PR TITLE
Upgrade gh packages to avoid Node.js warnings

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -120,7 +120,7 @@ jobs:
             sudo apt-get install -y clang xorg-dev libxinerama-dev libxcursor-dev libgles2-mesa-dev libegl1-mesa-dev libglfw3-dev libglew-dev libstdc++-12-dev
 
         - name: Prepare Vulkan SDK
-          uses: humbletim/setup-vulkan-sdk@v1.2.0
+          uses: humbletim/setup-vulkan-sdk@523828e49cd4afabce369c39c7ee6543a2b7a735
           with:
             vulkan-query-version: 1.3.268.0
             vulkan-components: Vulkan-Headers, Vulkan-Loader, SPIRV-Headers

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -127,7 +127,7 @@ jobs:
             vulkan-use-cache: true
 
         - name: Get the number of CPU cores
-          uses: SimenB/github-actions-cpu-cores@v1
+          uses: SimenB/github-actions-cpu-cores@v2
 
         - name: Build
           shell: bash

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,7 +21,7 @@ jobs:
           ndk-version: r25c
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'oracle'


### PR DESCRIPTION
Continue from issue #71 
- [x] upgrade SimenB/github-actions-cpu-cores pkg to v 2
- [x] upgrade actions/setup-java to v 4
- [x] upgrade humbletin/setup-vulkan-sdk pkg to  ~~a newest release~~  commit https://github.com/humbletim/setup-vulkan-sdk/commit/523828e49cd4afabce369c39c7ee6543a2b7a735