### PR TITLE
[igl] Fix warnings from IGL and shell headers

### DIFF
--- a/IGLU/sentinel/CommandBuffer.h
+++ b/IGLU/sentinel/CommandBuffer.h
@@ -31,7 +31,7 @@ class CommandBuffer final : public igl::ICommandBuffer {
   void present(std::shared_ptr<igl::ITexture> /*surface*/) const final;
   void waitUntilScheduled() final;
   void waitUntilCompleted() final;
-  void pushDebugGroupLabel(const char* /*label*/,
+  void pushDebugGroupLabel(const char* IGL_NONNULL /*label*/,
                            const igl::Color& /*color*/ = igl::Color(1, 1, 1, 1)) const final;
   void popDebugGroupLabel() const final;
 

--- a/IGLU/texture_loader/ktx/TextureLoaderFactory.h
+++ b/IGLU/texture_loader/ktx/TextureLoaderFactory.h
@@ -26,7 +26,7 @@ class TextureLoaderFactory : public ITextureLoaderFactory {
                                       igl::Result* IGL_NULLABLE outResult) const noexcept = 0;
 
   [[nodiscard]] virtual igl::TextureFormat textureFormat(
-      const ktxTexture* texture) const noexcept = 0;
+      const ktxTexture* IGL_NONNULL texture) const noexcept = 0;
 
  private:
   [[nodiscard]] std::unique_ptr<ITextureLoader> tryCreateInternal(

--- a/IGLU/texture_loader/ktx1/TextureLoaderFactory.h
+++ b/IGLU/texture_loader/ktx1/TextureLoaderFactory.h
@@ -32,7 +32,8 @@ class TextureLoaderFactory final : public ktx::TextureLoaderFactory {
                               const igl::TextureRangeDesc& range,
                               igl::Result* IGL_NULLABLE outResult) const noexcept final;
 
-  [[nodiscard]] igl::TextureFormat textureFormat(const ktxTexture* texture) const noexcept final;
+  [[nodiscard]] igl::TextureFormat textureFormat(
+      const ktxTexture* IGL_NONNULL texture) const noexcept final;
 };
 
 } // namespace iglu::textureloader::ktx1

--- a/IGLU/texture_loader/ktx2/TextureLoaderFactory.h
+++ b/IGLU/texture_loader/ktx2/TextureLoaderFactory.h
@@ -32,7 +32,8 @@ class TextureLoaderFactory final : public ktx::TextureLoaderFactory {
                               const igl::TextureRangeDesc& range,
                               igl::Result* IGL_NULLABLE outResult) const noexcept final;
 
-  [[nodiscard]] igl::TextureFormat textureFormat(const ktxTexture* texture) const noexcept final;
+  [[nodiscard]] igl::TextureFormat textureFormat(
+      const ktxTexture* IGL_NONNULL texture) const noexcept final;
 };
 
 } // namespace iglu::textureloader::ktx2

--- a/shell/shared/renderSession/RenderSession.h
+++ b/shell/shared/renderSession/RenderSession.h
@@ -25,7 +25,7 @@ class RenderSession {
 
   virtual void initialize() noexcept {}
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
-  virtual void update(igl::SurfaceTextures surfaceTextures) noexcept {}
+  virtual void update(IGL_MAYBE_UNUSED igl::SurfaceTextures surfaceTextures) noexcept {}
   virtual void dispose() noexcept {}
 
   void updateDisplayScale(float scale) noexcept;

--- a/src/igl/ColorSpace.h
+++ b/src/igl/ColorSpace.h
@@ -78,7 +78,7 @@ inline const char* IGL_NONNULL colorSpaceToString(ColorSpace colorSpace) {
 }
 
 inline igl::TextureFormat colorSpaceToTextureFormat(igl::ColorSpace colorSpace,
-                                                    bool isBGR = false) {
+                                                    IGL_MAYBE_UNUSED bool isBGR = false) {
   switch (colorSpace) {
   case igl::ColorSpace::SRGB_LINEAR:
     return igl::TextureFormat::RGBA_UNorm8;

--- a/src/igl/IResourceTracker.h
+++ b/src/igl/IResourceTracker.h
@@ -131,11 +131,11 @@ class IResourceTracker {
   virtual void willDelete(const IShaderStages& shaderStages) noexcept = 0;
 
   template<typename T>
-  void didCreate(const ITrackedResource<T>& resource) noexcept {
+  void didCreate(IGL_MAYBE_UNUSED const ITrackedResource<T>& resource) noexcept {
     IGL_ASSERT_NOT_REACHED();
   }
   template<typename T>
-  void willDelete(const ITrackedResource<T>& resource) noexcept {
+  void willDelete(IGL_MAYBE_UNUSED const ITrackedResource<T>& resource) noexcept {
     IGL_ASSERT_NOT_REACHED();
   }
 

--- a/src/igl/NameHandle.h
+++ b/src/igl/NameHandle.h
@@ -66,7 +66,7 @@ constexpr uint32_t iglCrc32ImplConstExpr(const char* p, uint32_t crc) {
  * @returns CRC32 representation of data
  */
 constexpr uint32_t iglCrc32ConstExpr(const char* data) {
-  return ~iglCrc32ImplConstExpr(data, ~0);
+  return ~iglCrc32ImplConstExpr(data, ~0u);
 }
 #endif // defined(__cpp_constexpr)
 


### PR DESCRIPTION
Headers are exposed to other libraries that use their own list of compiler diagnostic flags. Although it's not realistic for IGL to compile cleanly with all possible diagnostic flags enabled, it's reasonable for headers to be held at a higher quality bar than implementation files. This diff addresses a handful of -Wunused, -Wconvert and -Wnullability-completeness warnings.

Worth mentioning that building IGL itself on macOS generates a number of -Wdeprecated-declarations warnings. This change doesn’t address those.

Test plan:
- Verified that warnings are gone in a project using IGL as a dependency.
- Verified that IGL still builds with the `cmake .. -G Ninja -DIGL_WITH_VULKAN=OFF`.