### PR TITLE
[igl][shell][mac] Don't crash when tearing down the view controller

### DIFF
--- a/shell/mac/ViewController.mm
+++ b/shell/mac/ViewController.mm
@@ -103,6 +103,10 @@ using namespace igl;
 }
 
 - (void)render {
+  if (session_ == nullptr) {
+    return;
+  }
+
   shellParams_.viewportSize = glm::vec2(self.view.frame.size.width, self.view.frame.size.height);
   shellParams_.viewportScale = self.view.window.backingScaleFactor;
   session_->setShellParams(shellParams_);


### PR DESCRIPTION
This is a feature that's only on mac shell builds. From the app's toolbar, click Debug -> Tear down ViewController. It does as the name suggests, and it's useful to debug memory leaks in Xcode.

Apparently, there's a known bug in MTKView where it's never removed from its internal DisplayLink (see https://openradar.appspot.com/23977735). This new check at least prevents it from crashing when trying to render with a null render session.