### PR TITLE
[igl][IGLU] Some improvements to imgui and simple_renderer modules

### DIFF
--- a/IGLU/imgui/Session.cpp
+++ b/IGLU/imgui/Session.cpp
@@ -287,6 +287,9 @@ void Session::Renderer::newFrame(const igl::FramebufferDesc& desc) {
   _renderPipelineDesc.targetDesc.depthAttachmentFormat =
       desc.depthAttachment.texture ? desc.depthAttachment.texture->getFormat()
                                    : igl::TextureFormat::Invalid;
+  _renderPipelineDesc.targetDesc.stencilAttachmentFormat =
+      desc.stencilAttachment.texture ? desc.stencilAttachment.texture->getFormat()
+                                     : igl::TextureFormat::Invalid;
   _renderPipelineDesc.sampleCount = desc.colorAttachments[0].texture->getSamples();
 }
 

--- a/IGLU/simple_renderer/ForwardRenderPass.cpp
+++ b/IGLU/simple_renderer/ForwardRenderPass.cpp
@@ -30,6 +30,9 @@ void ForwardRenderPass::begin(std::shared_ptr<igl::IFramebuffer> target,
   auto depthAttachment = _framebuffer->getDepthAttachment();
   _renderPipelineDesc.targetDesc.depthAttachmentFormat =
       depthAttachment ? depthAttachment->getFormat() : igl::TextureFormat::Invalid;
+  auto stencilAttachment = _framebuffer->getStencilAttachment();
+  _renderPipelineDesc.targetDesc.stencilAttachmentFormat =
+      stencilAttachment ? stencilAttachment->getFormat() : igl::TextureFormat::Invalid;
 
   igl::RenderPassDesc defaultRenderPassDesc;
   defaultRenderPassDesc.colorAttachments.resize(1);

--- a/IGLU/simple_renderer/ForwardRenderPass.cpp
+++ b/IGLU/simple_renderer/ForwardRenderPass.cpp
@@ -83,8 +83,14 @@ bool ForwardRenderPass::isActive() const {
   return _framebuffer != nullptr;
 }
 
-std::shared_ptr<igl::IFramebuffer> ForwardRenderPass::activeTarget() {
-  return _framebuffer;
+igl::IFramebuffer& ForwardRenderPass::activeTarget() {
+  IGL_ASSERT_MSG(isActive(), "No valid target when not active");
+  return *_framebuffer;
+}
+
+igl::IRenderCommandEncoder& ForwardRenderPass::activeCommandEncoder() {
+  IGL_ASSERT_MSG(isActive(), "No valid command encoder when not active");
+  return *_commandEncoder;
 }
 
 } // namespace renderpass

--- a/IGLU/simple_renderer/ForwardRenderPass.h
+++ b/IGLU/simple_renderer/ForwardRenderPass.h
@@ -43,7 +43,8 @@ class ForwardRenderPass final {
 
   //// The render pass is considered active when in between begin() and end() calls.
   bool isActive() const;
-  std::shared_ptr<igl::IFramebuffer> activeTarget();
+  igl::IFramebuffer& activeTarget();
+  igl::IRenderCommandEncoder& activeCommandEncoder();
 
   explicit ForwardRenderPass(igl::IDevice& device);
   ~ForwardRenderPass() = default;


### PR DESCRIPTION
1. Expose the render command encoder in `simple_renderer::ForwardRenderPass`
2. ~~`Session::beginFrame()` takes a concrete framebuffer instead of a descriptor~~ -- had to remove because of internal conflicts
3. `simple_renderer` and `imgui` now work as expected when a stencil attachment exists