### PR TITLE
[igl] Fix tests on Apple platforms

### DIFF
--- a/src/igl/CMakeLists.txt
+++ b/src/igl/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 # tests are disabled for now on Windows
 if(IGL_WITH_TESTS AND IGL_WITH_IGLU AND (IGL_WITH_VULKAN OR (NOT WIN32)))
   add_subdirectory(tests)
-  if(IGL_WITH_OPENGL OR IGL_WITH_OPENGLES)
+  if((IGL_WITH_OPENGL OR IGL_WITH_OPENGLES) AND NOT APPLE)
     target_sources(IGLTests PRIVATE opengl/egl/Context.cpp opengl/egl/Device.cpp opengl/egl/HWDevice.cpp
                                     opengl/egl/PlatformDevice.cpp)
   endif()


### PR DESCRIPTION
Apple platforms don't support EGL.

Test plan:
- `cmake .. -G Ninja -DIGL_WITH_TESTS=ON -DIGL_WITH_VULKAN=OFF`