### PR TITLE
Add support to automatically set the Refresh rate to a specific value or the max.

### DIFF
--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -340,7 +340,7 @@ bool XrApp::createSystem() {
 
 bool XrApp::createPassthrough() {
   if (!passthroughSupported_) {
-      return false;
+    return false;
   }
   XrPassthroughCreateInfoFB passthroughInfo{XR_TYPE_PASSTHROUGH_CREATE_INFO_FB};
   passthroughInfo.next = nullptr;

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -339,6 +339,9 @@ bool XrApp::createSystem() {
 }
 
 bool XrApp::createPassthrough() {
+  if (!passthroughSupported_) {
+      return false;
+  }
   XrPassthroughCreateInfoFB passthroughInfo{XR_TYPE_PASSTHROUGH_CREATE_INFO_FB};
   passthroughInfo.next = nullptr;
   passthroughInfo.flags = 0u;
@@ -380,6 +383,9 @@ bool XrApp::createPassthrough() {
 }
 
 bool XrApp::createHandsTracking() {
+  if (!handsTrackingSupported_) {
+    return false;
+  }
   XrHandTrackerCreateInfoEXT createInfo{XR_TYPE_HAND_TRACKER_CREATE_INFO_EXT};
   createInfo.handJointSet = XR_HAND_JOINT_SET_DEFAULT_EXT;
   createInfo.hand = XR_HAND_LEFT_EXT;
@@ -413,6 +419,9 @@ bool XrApp::createHandsTracking() {
 }
 
 void XrApp::updateHandMeshes() {
+  if (!handsTrackingMeshSupported_) {
+    return;
+  }
   auto& handMeshes = shellParams_->handMeshes;
 
   XrResult result;
@@ -481,6 +490,9 @@ void XrApp::updateHandMeshes() {
 }
 
 void XrApp::updateHandTracking() {
+  if (!handsTrackingSupported_) {
+    return;
+  }
   auto& handTracking = shellParams_->handTracking;
 
   XrResult result;

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -1206,11 +1206,10 @@ void XrApp::querySupportedRefreshRates() {
       std::sort(supportedRefreshRates_.begin(), supportedRefreshRates_.end());
     }
 
-  for (float refreshRate : supportedRefreshRates_) {
-    IGL_LOG_INFO("querySupportedRefreshRates Hz = %.2f.", refreshRate);
+    for (float refreshRate : supportedRefreshRates_) {
+      IGL_LOG_INFO("querySupportedRefreshRates Hz = %.2f.", refreshRate);
+    }
   }
-}
-
 }
 
 } // namespace igl::shell::openxr

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -728,7 +728,7 @@ bool XrApp::initialize(const struct android_app* app) {
     return false;
   }
 
-#if 0
+#if 1
   if (refreshRateExtensionSupported_) {
     getCurrentRefreshRate();
     querySupportedRefreshRates();

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -751,13 +751,13 @@ bool XrApp::initialize(const struct android_app* app) {
   if (handsTrackingSupported_ && !createHandsTracking()) {
     return false;
   }
-  if (refreshRateExtensionSupported_) {
+  if (refreshRateExtensionSupported_ && (useMaxRefreshRate_ || useSpecificRefreshRate_)) {
     getCurrentRefreshRate();
 
     if (useMaxRefreshRate_) {
       setMaxRefreshRate();
     }
-    else {
+    else if (useSpecificRefreshRate_) {
       setRefreshRate(desiredSpecificRefreshRate_);
     }
   }

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -728,20 +728,6 @@ bool XrApp::initialize(const struct android_app* app) {
     return false;
   }
 
-#if 1
-  if (refreshRateExtensionSupported_) {
-    getCurrentRefreshRate();
-    querySupportedRefreshRates();
-
-    if (useMaxRefreshRate_){
-        setMaxRefreshRate();
-    }
-    else{
-        setRefreshRate(desiredSpecificRefreshRate_);
-    }
-  }
-#endif
-
   // The following are initialization steps that happen after XrSession is created.
   enumerateReferenceSpaces();
   enumerateBlendModes();
@@ -752,6 +738,16 @@ bool XrApp::initialize(const struct android_app* app) {
   }
   if (handsTrackingSupported_ && !createHandsTracking()) {
     return false;
+  }
+  if (refreshRateExtensionSupported_) {
+    getCurrentRefreshRate();
+
+    if (useMaxRefreshRate_){
+        setMaxRefreshRate();
+    }
+    else{
+        setRefreshRate(desiredSpecificRefreshRate_);
+    }
   }
 
   updateHandMeshes();

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -728,6 +728,7 @@ bool XrApp::initialize(const struct android_app* app) {
     return false;
   }
 
+#if 0
   if (refreshRateExtensionSupported_) {
     getCurrentRefreshRate();
     querySupportedRefreshRates();
@@ -739,6 +740,7 @@ bool XrApp::initialize(const struct android_app* app) {
         setRefreshRate(desiredSpecificRefreshRate_);
     }
   }
+#endif
 
   // The following are initialization steps that happen after XrSession is created.
   enumerateReferenceSpaces();

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -754,11 +754,11 @@ bool XrApp::initialize(const struct android_app* app) {
   if (refreshRateExtensionSupported_) {
     getCurrentRefreshRate();
 
-    if (useMaxRefreshRate_){
-        setMaxRefreshRate();
+    if (useMaxRefreshRate_) {
+      setMaxRefreshRate();
     }
-    else{
-        setRefreshRate(desiredSpecificRefreshRate_);
+    else {
+      setRefreshRate(desiredSpecificRefreshRate_);
     }
   }
 
@@ -1108,109 +1108,109 @@ void XrApp::update() {
 }
 
 float XrApp::getCurrentRefreshRate(){
-    if (!session_ || !refreshRateExtensionSupported_ || (currentRefreshRate_ > 0.0f)) {
-        return currentRefreshRate_;
-    }
-
-    XrResult result = xrGetDisplayRefreshRateFB_(session_, &currentRefreshRate_);
-
-    if (result == XR_SUCCESS) {
-        IGL_LOG_INFO("getCurrentRefreshRate success, current Hz = %.2f.", currentRefreshRate_);
-    }
-
+  if (!session_ || !refreshRateExtensionSupported_ || (currentRefreshRate_ > 0.0f)) {
     return currentRefreshRate_;
+  }
+
+  XrResult result = xrGetDisplayRefreshRateFB_(session_, &currentRefreshRate_);
+
+  if (result == XR_SUCCESS) {
+    IGL_LOG_INFO("getCurrentRefreshRate success, current Hz = %.2f.", currentRefreshRate_);
+  }
+
+  return currentRefreshRate_;
 }
 
 float XrApp::getMaxRefreshRate() {
-    if (!session_ || !refreshRateExtensionSupported_) {
-        return 0.0f;
-    }
+  if (!session_ || !refreshRateExtensionSupported_) {
+    return 0.0f;
+  }
 
-    const std::vector<float>& supportedRefreshRates = getSupportedRefreshRates();
+  const std::vector<float>& supportedRefreshRates = getSupportedRefreshRates();
 
-    if (supportedRefreshRates.empty()){
-        return 0.0f;
-    }
+  if (supportedRefreshRates.empty()) {
+    return 0.0f;
+  }
 
-    const float maxRefreshRate = supportedRefreshRates.back();
-    IGL_LOG_INFO("getMaxRefreshRate Hz = %.2f.",maxRefreshRate);
-    return maxRefreshRate;
+  const float maxRefreshRate = supportedRefreshRates.back();
+  IGL_LOG_INFO("getMaxRefreshRate Hz = %.2f.",maxRefreshRate);
+  return maxRefreshRate;
 }
 
-bool XrApp::setRefreshRate(const float refreshRate){
-
-    if (!session_ || !refreshRateExtensionSupported_
-        || (refreshRate == currentRefreshRate_)
-        || !isRefreshRateSupported(refreshRate)) {
-        return false;
-    }
-
-    XrResult result = xrRequestDisplayRefreshRateFB_(session_, refreshRate);
-
-    if (result == XR_SUCCESS) {
-        IGL_LOG_INFO("setRefreshRate SUCCESS, changed from %.2f Hz to %.2f Hz", currentRefreshRate_, refreshRate);
-        currentRefreshRate_ = refreshRate;
-
-        return true;
-    }
-
+bool XrApp::setRefreshRate(const float refreshRate) {
+  if (!session_ || !refreshRateExtensionSupported_
+  || (refreshRate == currentRefreshRate_)
+  || !isRefreshRateSupported(refreshRate)) {
     return false;
+  }
+
+  XrResult result = xrRequestDisplayRefreshRateFB_(session_, refreshRate);
+
+  if (result == XR_SUCCESS) {
+    IGL_LOG_INFO("setRefreshRate SUCCESS, changed from %.2f Hz to %.2f Hz", currentRefreshRate_, refreshRate);
+    currentRefreshRate_ = refreshRate;
+
+    return true;
+  }
+
+  return false;
 }
 
-void XrApp::setMaxRefreshRate(){
-    if (!session_ || !refreshRateExtensionSupported_) {
-        return;
-    }
+void XrApp::setMaxRefreshRate() {
+  if (!session_ || !refreshRateExtensionSupported_) {
+    return;
+  }
 
-    const float maxRefreshRate = getMaxRefreshRate();
+  const float maxRefreshRate = getMaxRefreshRate();
 
-    if (maxRefreshRate > 0.0f){
-        setRefreshRate(maxRefreshRate);
-    }
+  if (maxRefreshRate > 0.0f) {
+    setRefreshRate(maxRefreshRate);
+  }
 }
 
-bool XrApp::isRefreshRateSupported(const float refreshRate){
-    if (!session_ || !refreshRateExtensionSupported_) {
-        return false;
-    }
+bool XrApp::isRefreshRateSupported(const float refreshRate) {
+  if (!session_ || !refreshRateExtensionSupported_) {
+    return false;
+  }
 
-    const std::vector<float>& supportedRefreshRates = getSupportedRefreshRates();
-    const bool found_it = (std::find(supportedRefreshRates.begin(), supportedRefreshRates.end(), refreshRate) != supportedRefreshRates.end());
-    return found_it;
+  const std::vector<float>& supportedRefreshRates = getSupportedRefreshRates();
+  const bool found_it = (std::find(supportedRefreshRates.begin(), supportedRefreshRates.end(), refreshRate) != supportedRefreshRates.end());
+  return found_it;
 }
 
-const std::vector<float>& XrApp::getSupportedRefreshRates()  {
-    if (!session_ || !refreshRateExtensionSupported_) {
-        return supportedRefreshRates_;
-    }
-
-    if (supportedRefreshRates_.empty()){
-        querySupportedRefreshRates();
-    }
-
+const std::vector<float>& XrApp::getSupportedRefreshRates() {
+  if (!session_ || !refreshRateExtensionSupported_) {
     return supportedRefreshRates_;
+  }
+
+  if (supportedRefreshRates_.empty()) {
+    querySupportedRefreshRates();
+  }
+
+  return supportedRefreshRates_;
 }
 
 void XrApp::querySupportedRefreshRates() {
-    if (!session_ || !refreshRateExtensionSupported_ || !supportedRefreshRates_.empty()) {
-        return;
+  if (!session_ || !refreshRateExtensionSupported_ || !supportedRefreshRates_.empty()) {
+    return;
+  }
+
+  uint32_t numRefreshRates = 0;
+  XrResult result = xrEnumerateDisplayRefreshRatesFB_(session_, 0, &numRefreshRates, nullptr);
+
+  if ((result == XR_SUCCESS) && (numRefreshRates > 0)) {
+    supportedRefreshRates_.resize(numRefreshRates);
+    result = xrEnumerateDisplayRefreshRatesFB_(session_, numRefreshRates, &numRefreshRates, supportedRefreshRates_.data());
+
+    if (result == XR_SUCCESS) {
+      std::sort(supportedRefreshRates_.begin(), supportedRefreshRates_.end());
     }
 
-    uint32_t numRefreshRates = 0;
-    XrResult result = xrEnumerateDisplayRefreshRatesFB_(session_, 0, &numRefreshRates, nullptr);
+  for (float refreshRate : supportedRefreshRates_) {
+    IGL_LOG_INFO("querySupportedRefreshRates Hz = %.2f.", refreshRate);
+  }
+}
 
-    if ((result == XR_SUCCESS) && (numRefreshRates > 0)) {
-        supportedRefreshRates_.resize(numRefreshRates);
-        result = xrEnumerateDisplayRefreshRatesFB_(session_, numRefreshRates, &numRefreshRates, supportedRefreshRates_.data());
-
-        if (result == XR_SUCCESS) {
-            std::sort(supportedRefreshRates_.begin(), supportedRefreshRates_.end());
-        }
-
-        for (float refreshRate : supportedRefreshRates_) {
-            IGL_LOG_INFO("querySupportedRefreshRates Hz = %.2f.", refreshRate);
-        }
-    }
 }
 
 } // namespace igl::shell::openxr

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -1064,4 +1064,55 @@ void XrApp::update() {
   render();
   endFrame(frameState);
 }
+
+bool XrApp::setRefreshRate(const float refreshRate){
+
+    if (!initialized_ || !resumed_ || !sessionActive_ ||
+        !refreshRateExtensionSupported_
+        || (refreshRate == currentRefreshRate_)
+        || !isRefreshRateSupported(refreshRate)) {
+        return false;
+    }
+
+    // Do it
+    currentRefreshRate_ = refreshRate;
+
+    return true;
+}
+
+bool XrApp::isRefreshRateSupported(const float refreshRate){
+    if (!initialized_ || !resumed_ || !sessionActive_ || !refreshRateExtensionSupported_) {
+        return false;
+    }
+
+    const std::vector<float>& supportedRefreshRates = getSupportedRefreshRates();
+
+    for(const float& supportedRefreshRate : supportedRefreshRates){
+        if (fabs(refreshRate - supportedRefreshRate) < FLT_EPSILON){
+            return true;
+        }
+    }
+
+    return false;
+}
+
+const std::vector<float>& XrApp::getSupportedRefreshRates()  {
+    if (!initialized_ || !resumed_ || !sessionActive_ || !refreshRateExtensionSupported_) {
+        return supportedRefreshRates_;
+    }
+
+    if (supportedRefreshRates_.empty()){
+        querySupportedRefreshRates();
+    }
+
+    return supportedRefreshRates_;
+}
+
+void XrApp::querySupportedRefreshRates() {
+    if (!initialized_ || !resumed_ || !sessionActive_ || !refreshRateExtensionSupported_ || !supportedRefreshRates_.empty()) {
+        return;
+    }
+
+}
+
 } // namespace igl::shell::openxr

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -728,6 +728,18 @@ bool XrApp::initialize(const struct android_app* app) {
     return false;
   }
 
+  if (refreshRateExtensionSupported_) {
+    getCurrentRefreshRate();
+    querySupportedRefreshRates();
+
+    if (useMaxRefreshRate_){
+        setMaxRefreshRate();
+    }
+    else{
+        setRefreshRate(desiredSpecificRefreshRate_);
+    }
+  }
+
   // The following are initialization steps that happen after XrSession is created.
   enumerateReferenceSpaces();
   enumerateBlendModes();
@@ -864,18 +876,6 @@ void XrApp::handleSessionStateChanges(XrSessionState state) {
 
     sessionActive_ = (result == XR_SUCCESS);
     IGL_LOG_INFO("XR session active");
-
-    if (sessionActive_ && refreshRateExtensionSupported_) {
-      getCurrentRefreshRate();
-      querySupportedRefreshRates();
-
-      if (useMaxRefreshRate_){
-          setMaxRefreshRate();
-      }
-      else{
-          setRefreshRate(desiredSpecificRefreshRate_);
-      }
-    }
   } else if (state == XR_SESSION_STATE_STOPPING) {
     assert(resumed_ == false);
     assert(sessionActive_);
@@ -1098,9 +1098,7 @@ void XrApp::update() {
 }
 
 float XrApp::getCurrentRefreshRate(){
-
-    if (!initialized_ || !resumed_ || !sessionActive_ ||
-        !refreshRateExtensionSupported_ || (currentRefreshRate_ > 0.0f)) {
+    if (!session_ || !refreshRateExtensionSupported_ || (currentRefreshRate_ > 0.0f)) {
         return currentRefreshRate_;
     }
 
@@ -1114,8 +1112,7 @@ float XrApp::getCurrentRefreshRate(){
 }
 
 float XrApp::getMaxRefreshRate() {
-    if (!initialized_ || !resumed_ || !sessionActive_ ||
-        !refreshRateExtensionSupported_) {
+    if (!session_ || !refreshRateExtensionSupported_) {
         return 0.0f;
     }
 
@@ -1132,8 +1129,7 @@ float XrApp::getMaxRefreshRate() {
 
 bool XrApp::setRefreshRate(const float refreshRate){
 
-    if (!initialized_ || !resumed_ || !sessionActive_ ||
-        !refreshRateExtensionSupported_
+    if (!session_ || !refreshRateExtensionSupported_
         || (refreshRate == currentRefreshRate_)
         || !isRefreshRateSupported(refreshRate)) {
         return false;
@@ -1152,7 +1148,7 @@ bool XrApp::setRefreshRate(const float refreshRate){
 }
 
 void XrApp::setMaxRefreshRate(){
-    if (!initialized_ || !resumed_ || !sessionActive_ || !refreshRateExtensionSupported_) {
+    if (!session_ || !refreshRateExtensionSupported_) {
         return;
     }
 
@@ -1164,7 +1160,7 @@ void XrApp::setMaxRefreshRate(){
 }
 
 bool XrApp::isRefreshRateSupported(const float refreshRate){
-    if (!initialized_ || !resumed_ || !sessionActive_ || !refreshRateExtensionSupported_) {
+    if (!session_ || !refreshRateExtensionSupported_) {
         return false;
     }
 
@@ -1174,7 +1170,7 @@ bool XrApp::isRefreshRateSupported(const float refreshRate){
 }
 
 const std::vector<float>& XrApp::getSupportedRefreshRates()  {
-    if (!initialized_ || !resumed_ || !sessionActive_ || !refreshRateExtensionSupported_) {
+    if (!session_ || !refreshRateExtensionSupported_) {
         return supportedRefreshRates_;
     }
 
@@ -1186,7 +1182,7 @@ const std::vector<float>& XrApp::getSupportedRefreshRates()  {
 }
 
 void XrApp::querySupportedRefreshRates() {
-    if (!initialized_ || !resumed_ || !sessionActive_ || !refreshRateExtensionSupported_ || !supportedRefreshRates_.empty()) {
+    if (!session_ || !refreshRateExtensionSupported_ || !supportedRefreshRates_.empty()) {
         return;
     }
 

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.igl.shell.openxr.gles"
-    android:versionCode="1"
-    android:versionName="1.0"
-    android:installLocation="auto">
+          package="com.facebook.igl.shell.openxr.gles"
+          android:versionCode="1"
+          android:versionName="1.0"
+          android:installLocation="auto">
   <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="25" />
   <uses-feature android:glEsVersion="0x00030000"/>
   <uses-feature android:name="com.oculus.experimental.enabled" android:required="false" />
@@ -15,9 +15,9 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 
-  <queries>
-    <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
-  </queries>
+    <queries>
+        <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
+    </queries>
 
   <application
       android:allowBackup="false"
@@ -27,19 +27,19 @@
     <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|quest3|questpro"/>
 
     <activity android:name="android.app.NativeActivity"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-        android:launchMode="singleTask"
-        android:exported="true"
-        android:screenOrientation="landscape"
-        android:excludeFromRecents="false"
-        android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
-      <!-- This filter lets the apk show up as a launchable icon. -->
+              android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+              android:launchMode="singleTask"
+              android:exported="true"
+              android:screenOrientation="landscape"
+				      android:excludeFromRecents="false"
+              android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
+			<!-- This filter lets the apk show up as a launchable icon. -->
       <meta-data android:name="android.app.lib_name" android:value="openxr-gles-Jni" />
       <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
+				<action android:name="android.intent.action.MAIN" />
         <category android:name="com.oculus.intent.category.VR" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
+				<category android:name="android.intent.category.LAUNCHER" />
+			</intent-filter>
     </activity>
   </application>
 </manifest>

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -13,10 +13,6 @@
   <uses-feature android:name="android.hardware.microphone" android:required="false" />
 
   <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.RECORD_AUDIO" />
-  <uses-permission android:name="android.permission.BLUETOOTH" />
-  <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
   <uses-feature android:name="oculus.software.handtracking" android:required="false" />
   <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.igl.shell.openxr.gles"
+    package="com.facebook.igl.shell.openxr.vulkan"
     android:versionCode="1"
     android:versionName="1.0"
     android:installLocation="auto">

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -34,15 +34,13 @@
         android:screenOrientation="landscape"
         android:excludeFromRecents="false"
         android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
-
+      <!-- This filter lets the apk show up as a launchable icon. -->
       <meta-data android:name="android.app.lib_name" android:value="openxr-gles-Jni" />
-
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="com.oculus.intent.category.VR" />
         <category android:name="android.intent.category.LAUNCHER" />
         <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
-        <category android:name="com.htc.intent.category.VRAPP" />
       </intent-filter>
     </activity>
   </application>

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -4,41 +4,16 @@
     android:versionCode="1"
     android:versionName="1.0"
     android:installLocation="auto">
-
-  <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1" />
-
+  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="25" />
+  <uses-feature android:glEsVersion="0x00030000"/>
+  <uses-feature android:name="com.oculus.experimental.enabled" android:required="false" />
   <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
-  <uses-permission android:name="android.permission.INTERNET" />
-
   <uses-feature android:name="oculus.software.handtracking" android:required="false" />
+
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
-
-  <uses-feature android:name="pico.software.handtracking" android:required="false" />
-  <uses-permission android:name="com.picovr.permission.HAND_TRACKING"/>
-
-  <uses-feature android:name="htc.software.handtracking" android:required="false" />
-  <uses-permission android:name="com.htc.permission.HAND_TRACKING"/>
-
-  <uses-feature android:name="com.oculus.experimental.enabled" />
-
-  <uses-feature android:name="oculus.software.eye_tracking" android:required="false" />
-  <uses-permission android:name="com.oculus.permission.EYE_TRACKING" />
-
-  <uses-feature android:name="pico.software.eye_tracking" android:required="false" />
-  <uses-permission android:name="com.picovr.permission.EYE_TRACKING"/>
-
-  <uses-feature android:name="htc.software.eye_tracking" android:required="false" />
-  <uses-permission android:name="com.htc.permission.EYE_TRACKING"/>
-
-  <uses-feature android:name="oculus.software.face_tracking" android:required="false" />
-  <uses-permission android:name="com.oculus.permission.FACE_TRACKING" />
-
-  <uses-feature android:name="com.oculus.software.body_tracking" />
-  <uses-permission android:name="com.oculus.permission.BODY_TRACKING" />
-
-  <uses-permission android:name="android.permission.VIBRATE" />
-  <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
-  <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
 
   <queries>
     <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -30,7 +30,6 @@
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
         android:launchMode="singleTask"
         android:exported="true"
-        android:resizeableActivity="false"
         android:screenOrientation="landscape"
         android:excludeFromRecents="false"
         android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
@@ -40,7 +39,6 @@
         <action android:name="android.intent.action.MAIN" />
         <category android:name="com.oculus.intent.category.VR" />
         <category android:name="android.intent.category.LAUNCHER" />
-        <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
       </intent-filter>
     </activity>
   </application>

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -25,15 +25,7 @@
       android:label="IGL Shell OpenXR OpenGL ES">
 
     <meta-data android:name="com.oculus.vr.focusaware" android:value="true"/>
-    <meta-data android:name="com.samsung.android.vr.application_mode" android:value="vr_only"/>
     <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|quest3|questpro"/>
-    <meta-data android:name="com.oculus.handtracking.version" android:value="V2.2"/>
-
-    <meta-data android:name="com.htc.vr.content.NumDoFHmd" android:value="6DoF"/>
-    <meta-data android:name="com.htc.vr.content.NumDoFController" android:value="6DoF"/>
-    <meta-data android:name="com.htc.vr.content.NumController" android:value="2"/>
-
-    <meta-data android:name="pvr.app.type" android:value="vr" />
 
     <activity android:name="android.app.NativeActivity"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -5,13 +5,9 @@
     android:versionName="1.0"
     android:installLocation="auto">
 
-  <uses-feature android:name="android.hardware.usb.host" />
-
   <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1" />
 
   <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
-  <uses-feature android:name="android.hardware.microphone" android:required="false" />
-
   <uses-permission android:name="android.permission.INTERNET" />
 
   <uses-feature android:name="oculus.software.handtracking" android:required="false" />

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -1,42 +1,91 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.facebook.igl.shell.openxr.gles"
-          android:versionCode="1"
-          android:versionName="1.0"
-          android:installLocation="auto">
-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="25" />
-  <uses-feature android:glEsVersion="0x00030000"/>
-  <uses-feature android:name="com.oculus.experimental.enabled" android:required="false" />
-  <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
-  <uses-feature android:name="oculus.software.handtracking" android:required="false" />
+    package="com.facebook.igl.shell.openxr.gles"
+    android:versionCode="1"
+    android:versionName="1.0"
+    android:installLocation="auto">
 
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-feature android:name="android.hardware.usb.host" />
+
+  <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1" />
+
+  <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
+  <uses-feature android:name="android.hardware.microphone" android:required="false" />
+
   <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.RECORD_AUDIO" />
+  <uses-permission android:name="android.permission.BLUETOOTH" />
+  <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+
+  <uses-feature android:name="oculus.software.handtracking" android:required="false" />
   <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 
-    <queries>
-        <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
-    </queries>
+  <uses-feature android:name="pico.software.handtracking" android:required="false" />
+  <uses-permission android:name="com.picovr.permission.HAND_TRACKING"/>
+
+  <uses-feature android:name="htc.software.handtracking" android:required="false" />
+  <uses-permission android:name="com.htc.permission.HAND_TRACKING"/>
+
+  <uses-feature android:name="com.oculus.experimental.enabled" />
+
+  <uses-feature android:name="oculus.software.eye_tracking" android:required="false" />
+  <uses-permission android:name="com.oculus.permission.EYE_TRACKING" />
+
+  <uses-feature android:name="pico.software.eye_tracking" android:required="false" />
+  <uses-permission android:name="com.picovr.permission.EYE_TRACKING"/>
+
+  <uses-feature android:name="htc.software.eye_tracking" android:required="false" />
+  <uses-permission android:name="com.htc.permission.EYE_TRACKING"/>
+
+  <uses-feature android:name="oculus.software.face_tracking" android:required="false" />
+  <uses-permission android:name="com.oculus.permission.FACE_TRACKING" />
+
+  <uses-feature android:name="com.oculus.software.body_tracking" />
+  <uses-permission android:name="com.oculus.permission.BODY_TRACKING" />
+
+  <uses-permission android:name="android.permission.VIBRATE" />
+  <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
+  <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
+
+  <queries>
+    <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
+  </queries>
 
   <application
       android:allowBackup="false"
       android:fullBackupContent="false"
       android:label="IGL Shell OpenXR OpenGL ES">
+
+    <meta-data android:name="com.oculus.vr.focusaware" android:value="true"/>
+    <meta-data android:name="com.samsung.android.vr.application_mode" android:value="vr_only"/>
+    <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|quest3|questpro"/>
+    <meta-data android:name="com.oculus.handtracking.version" android:value="V2.2"/>
+
+    <meta-data android:name="com.htc.vr.content.NumDoFHmd" android:value="6DoF"/>
+    <meta-data android:name="com.htc.vr.content.NumDoFController" android:value="6DoF"/>
+    <meta-data android:name="com.htc.vr.content.NumController" android:value="2"/>
+
+    <meta-data android:name="pvr.app.type" android:value="vr" />
+
     <activity android:name="android.app.NativeActivity"
-              android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-              android:launchMode="singleTask"
-              android:exported="true"
-              android:screenOrientation="landscape"
-				      android:excludeFromRecents="false"
-              android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
-			<!-- This filter lets the apk show up as a launchable icon. -->
+        android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+        android:launchMode="singleTask"
+        android:exported="true"
+        android:resizeableActivity="false"
+        android:screenOrientation="landscape"
+        android:excludeFromRecents="false"
+        android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
+
       <meta-data android:name="android.app.lib_name" android:value="openxr-gles-Jni" />
+
       <intent-filter>
-				<action android:name="android.intent.action.MAIN" />
+        <action android:name="android.intent.action.MAIN" />
         <category android:name="com.oculus.intent.category.VR" />
-				<category android:name="android.intent.category.LAUNCHER" />
-			</intent-filter>
+        <category android:name="android.intent.category.LAUNCHER" />
+        <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+        <category android:name="com.htc.intent.category.VRAPP" />
+      </intent-filter>
     </activity>
   </application>
 </manifest>

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -24,7 +24,6 @@
       android:fullBackupContent="false"
       android:label="IGL Shell OpenXR OpenGL ES">
 
-    <meta-data android:name="com.oculus.vr.focusaware" android:value="true"/>
     <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|quest3|questpro"/>
 
     <activity android:name="android.app.NativeActivity"

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.igl.shell.openxr.vulkan"
+    package="com.facebook.igl.shell.openxr.gles"
     android:versionCode="1"
     android:versionName="1.0"
     android:installLocation="auto">

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -1,44 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-package="com.facebook.igl.shell.openxr.vulkan"
-android:versionCode="1"
-android:versionName="1.0"
-android:installLocation="auto">
+    package="com.facebook.igl.shell.openxr.vulkan"
+    android:versionCode="1"
+    android:versionName="1.0"
+    android:installLocation="auto">
+    <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="25" />
+    <uses-feature android:glEsVersion="0x00030000"/>
+    <uses-feature android:name="com.oculus.experimental.enabled" android:required="false" />
+    <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
+    <uses-feature android:name="oculus.software.handtracking" android:required="false" />
 
-<uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1" />
-
-<uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
-<uses-permission android:name="android.permission.INTERNET" />
-
-<uses-feature android:name="oculus.software.handtracking" android:required="false" />
-<uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
-
-<uses-feature android:name="pico.software.handtracking" android:required="false" />
-<uses-permission android:name="com.picovr.permission.HAND_TRACKING"/>
-
-<uses-feature android:name="htc.software.handtracking" android:required="false" />
-<uses-permission android:name="com.htc.permission.HAND_TRACKING"/>
-
-<uses-feature android:name="com.oculus.experimental.enabled" />
-
-<uses-feature android:name="oculus.software.eye_tracking" android:required="false" />
-<uses-permission android:name="com.oculus.permission.EYE_TRACKING" />
-
-<uses-feature android:name="pico.software.eye_tracking" android:required="false" />
-<uses-permission android:name="com.picovr.permission.EYE_TRACKING"/>
-
-<uses-feature android:name="htc.software.eye_tracking" android:required="false" />
-<uses-permission android:name="com.htc.permission.EYE_TRACKING"/>
-
-<uses-feature android:name="oculus.software.face_tracking" android:required="false" />
-<uses-permission android:name="com.oculus.permission.FACE_TRACKING" />
-
-<uses-feature android:name="com.oculus.software.body_tracking" />
-<uses-permission android:name="com.oculus.permission.BODY_TRACKING" />
-
-<uses-permission android:name="android.permission.VIBRATE" />
-<uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
-<uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 
 <queries>
     <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -13,10 +13,6 @@ android:installLocation="auto">
 <uses-feature android:name="android.hardware.microphone" android:required="false" />
 
 <uses-permission android:name="android.permission.INTERNET" />
-<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-<uses-permission android:name="android.permission.RECORD_AUDIO" />
-<uses-permission android:name="android.permission.BLUETOOTH" />
-<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
 <uses-feature android:name="oculus.software.handtracking" android:required="false" />
 <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -5,13 +5,9 @@ android:versionCode="1"
 android:versionName="1.0"
 android:installLocation="auto">
 
-<uses-feature android:name="android.hardware.usb.host" />
-
 <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1" />
 
 <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
-<uses-feature android:name="android.hardware.microphone" android:required="false" />
-
 <uses-permission android:name="android.permission.INTERNET" />
 
 <uses-feature android:name="oculus.software.handtracking" android:required="false" />

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -1,42 +1,91 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.facebook.igl.shell.openxr.vulkan"
-          android:versionCode="1"
-          android:versionName="1.0"
-          android:installLocation="auto">
-  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="25" />
-  <uses-feature android:glEsVersion="0x00030000"/>
-  <uses-feature android:name="com.oculus.experimental.enabled" android:required="false" />
-  <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
-  <uses-feature android:name="oculus.software.handtracking" android:required="false" />
+package="com.facebook.igl.shell.openxr.gles"
+android:versionCode="1"
+android:versionName="1.0"
+android:installLocation="auto">
 
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
+<uses-feature android:name="android.hardware.usb.host" />
 
-    <queries>
-        <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
-    </queries>
+<uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1" />
 
-  <application
-      android:allowBackup="false"
-      android:fullBackupContent="false"
-      android:label="IGL Shell OpenXR Vulkan">
+<uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
+<uses-feature android:name="android.hardware.microphone" android:required="false" />
+
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+<uses-permission android:name="android.permission.BLUETOOTH" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+
+<uses-feature android:name="oculus.software.handtracking" android:required="false" />
+<uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
+
+<uses-feature android:name="pico.software.handtracking" android:required="false" />
+<uses-permission android:name="com.picovr.permission.HAND_TRACKING"/>
+
+<uses-feature android:name="htc.software.handtracking" android:required="false" />
+<uses-permission android:name="com.htc.permission.HAND_TRACKING"/>
+
+<uses-feature android:name="com.oculus.experimental.enabled" />
+
+<uses-feature android:name="oculus.software.eye_tracking" android:required="false" />
+<uses-permission android:name="com.oculus.permission.EYE_TRACKING" />
+
+<uses-feature android:name="pico.software.eye_tracking" android:required="false" />
+<uses-permission android:name="com.picovr.permission.EYE_TRACKING"/>
+
+<uses-feature android:name="htc.software.eye_tracking" android:required="false" />
+<uses-permission android:name="com.htc.permission.EYE_TRACKING"/>
+
+<uses-feature android:name="oculus.software.face_tracking" android:required="false" />
+<uses-permission android:name="com.oculus.permission.FACE_TRACKING" />
+
+<uses-feature android:name="com.oculus.software.body_tracking" />
+<uses-permission android:name="com.oculus.permission.BODY_TRACKING" />
+
+<uses-permission android:name="android.permission.VIBRATE" />
+<uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
+<uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
+
+<queries>
+    <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
+</queries>
+
+<application
+    android:allowBackup="false"
+    android:fullBackupContent="false"
+    android:label="IGL Shell OpenXR Vulkan">
+
+    <meta-data android:name="com.oculus.vr.focusaware" android:value="true"/>
+    <meta-data android:name="com.samsung.android.vr.application_mode" android:value="vr_only"/>
+    <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|quest3|questpro"/>
+    <meta-data android:name="com.oculus.handtracking.version" android:value="V2.2"/>
+
+    <meta-data android:name="com.htc.vr.content.NumDoFHmd" android:value="6DoF"/>
+    <meta-data android:name="com.htc.vr.content.NumDoFController" android:value="6DoF"/>
+    <meta-data android:name="com.htc.vr.content.NumController" android:value="2"/>
+
+    <meta-data android:name="pvr.app.type" android:value="vr" />
+
     <activity android:name="android.app.NativeActivity"
-              android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-              android:launchMode="singleTask"
-              android:exported="true"
-              android:screenOrientation="landscape"
-				      android:excludeFromRecents="false"
-              android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
-			<!-- This filter lets the apk show up as a launchable icon. -->
-      <meta-data android:name="android.app.lib_name" android:value="openxr-vulkan-Jni" />
-      <intent-filter>
-				<action android:name="android.intent.action.MAIN" />
-        <category android:name="com.oculus.intent.category.VR" />
-				<category android:name="android.intent.category.LAUNCHER" />
-			</intent-filter>
+        android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+        android:launchMode="singleTask"
+        android:exported="true"
+        android:resizeableActivity="false"
+        android:screenOrientation="landscape"
+        android:excludeFromRecents="false"
+        android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
+
+        <meta-data android:name="android.app.lib_name" android:value="openxr-vulkan-Jni" />
+
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="com.oculus.intent.category.VR" />
+            <category android:name="android.intent.category.LAUNCHER" />
+            <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+            <category android:name="com.htc.intent.category.VRAPP" />
+        </intent-filter>
     </activity>
-  </application>
+</application>
 </manifest>

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -25,15 +25,7 @@
     android:label="IGL Shell OpenXR Vulkan">
 
     <meta-data android:name="com.oculus.vr.focusaware" android:value="true"/>
-    <meta-data android:name="com.samsung.android.vr.application_mode" android:value="vr_only"/>
     <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|quest3|questpro"/>
-    <meta-data android:name="com.oculus.handtracking.version" android:value="V2.2"/>
-
-    <meta-data android:name="com.htc.vr.content.NumDoFHmd" android:value="6DoF"/>
-    <meta-data android:name="com.htc.vr.content.NumDoFController" android:value="6DoF"/>
-    <meta-data android:name="com.htc.vr.content.NumController" android:value="2"/>
-
-    <meta-data android:name="pvr.app.type" android:value="vr" />
 
     <activity android:name="android.app.NativeActivity"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -24,7 +24,6 @@
     android:fullBackupContent="false"
     android:label="IGL Shell OpenXR Vulkan">
 
-    <meta-data android:name="com.oculus.vr.focusaware" android:value="true"/>
     <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|quest3|questpro"/>
 
     <activity android:name="android.app.NativeActivity"

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -34,15 +34,13 @@
         android:screenOrientation="landscape"
         android:excludeFromRecents="false"
         android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
-
+        <!-- This filter lets the apk show up as a launchable icon. -->
         <meta-data android:name="android.app.lib_name" android:value="openxr-vulkan-Jni" />
-
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="com.oculus.intent.category.VR" />
             <category android:name="android.intent.category.LAUNCHER" />
             <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
-            <category android:name="com.htc.intent.category.VRAPP" />
         </intent-filter>
     </activity>
 </application>

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-package="com.facebook.igl.shell.openxr.gles"
+package="com.facebook.igl.shell.openxr.vulkan"
 android:versionCode="1"
 android:versionName="1.0"
 android:installLocation="auto">

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -30,7 +30,6 @@
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
         android:launchMode="singleTask"
         android:exported="true"
-        android:resizeableActivity="false"
         android:screenOrientation="landscape"
         android:excludeFromRecents="false"
         android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
@@ -40,7 +39,6 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="com.oculus.intent.category.VR" />
             <category android:name="android.intent.category.LAUNCHER" />
-            <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
         </intent-filter>
     </activity>
 </application>

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -1,45 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.igl.shell.openxr.vulkan"
-    android:versionCode="1"
-    android:versionName="1.0"
-    android:installLocation="auto">
-    <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="25" />
-    <uses-feature android:glEsVersion="0x00030000"/>
-    <uses-feature android:name="com.oculus.experimental.enabled" android:required="false" />
-    <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
-    <uses-feature android:name="oculus.software.handtracking" android:required="false" />
+          package="com.facebook.igl.shell.openxr.vulkan"
+          android:versionCode="1"
+          android:versionName="1.0"
+          android:installLocation="auto">
+  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="25" />
+  <uses-feature android:glEsVersion="0x00030000"/>
+  <uses-feature android:name="com.oculus.experimental.enabled" android:required="false" />
+  <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
+  <uses-feature android:name="oculus.software.handtracking" android:required="false" />
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
 
-<queries>
-    <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
-</queries>
+    <queries>
+        <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
+    </queries>
 
-<application
-    android:allowBackup="false"
-    android:fullBackupContent="false"
-    android:label="IGL Shell OpenXR Vulkan">
+  <application
+      android:allowBackup="false"
+      android:fullBackupContent="false"
+      android:label="IGL Shell OpenXR Vulkan">
 
     <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|quest3|questpro"/>
 
     <activity android:name="android.app.NativeActivity"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-        android:launchMode="singleTask"
-        android:exported="true"
-        android:screenOrientation="landscape"
-        android:excludeFromRecents="false"
-        android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
-        <!-- This filter lets the apk show up as a launchable icon. -->
-        <meta-data android:name="android.app.lib_name" android:value="openxr-vulkan-Jni" />
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="com.oculus.intent.category.VR" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
+              android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+              android:launchMode="singleTask"
+              android:exported="true"
+              android:screenOrientation="landscape"
+				      android:excludeFromRecents="false"
+              android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
+			<!-- This filter lets the apk show up as a launchable icon. -->
+      <meta-data android:name="android.app.lib_name" android:value="openxr-vulkan-Jni" />
+      <intent-filter>
+				<action android:name="android.intent.action.MAIN" />
+        <category android:name="com.oculus.intent.category.VR" />
+				<category android:name="android.intent.category.LAUNCHER" />
+			</intent-filter>
     </activity>
-</application>
+  </application>
 </manifest>

--- a/shell/openxr/src/XrApp.h
+++ b/shell/openxr/src/XrApp.h
@@ -110,6 +110,10 @@ class XrApp {
   void render();
   void endFrame(XrFrameState frameState);
 
+  bool setRefreshRate(const float refreshRate);
+  bool isRefreshRateSupported(const float refreshRate);
+  const std::vector<float>& getSupportedRefreshRates();
+
  private:
   void* nativeWindow_ = nullptr;
   bool resumed_ = false;
@@ -172,6 +176,11 @@ class XrApp {
 
   XrHandTrackerEXT leftHandTracker_ = XR_NULL_HANDLE;
   XrHandTrackerEXT rightHandTracker_ = XR_NULL_HANDLE;
+
+  bool refreshRateExtensionSupported_ = false;
+  std::vector<float> supportedRefreshRates_;
+  float currentRefreshRate_ = 0.0f;
+  void querySupportedRefreshRates();
 
   std::unique_ptr<impl::XrAppImpl> impl_;
 

--- a/shell/openxr/src/XrApp.h
+++ b/shell/openxr/src/XrApp.h
@@ -110,7 +110,10 @@ class XrApp {
   void render();
   void endFrame(XrFrameState frameState);
 
+  float getCurrentRefreshRate();
+  float getMaxRefreshRate();
   bool setRefreshRate(const float refreshRate);
+  void setMaxRefreshRate();
   bool isRefreshRateSupported(const float refreshRate);
   const std::vector<float>& getSupportedRefreshRates();
 
@@ -178,9 +181,14 @@ class XrApp {
   XrHandTrackerEXT rightHandTracker_ = XR_NULL_HANDLE;
 
   bool refreshRateExtensionSupported_ = false;
+  bool useMaxRefreshRate_ = false;
+  float desiredSpecificRefreshRate_ = 90.0f;
   std::vector<float> supportedRefreshRates_;
   float currentRefreshRate_ = 0.0f;
   void querySupportedRefreshRates();
+  PFN_xrGetDisplayRefreshRateFB xrGetDisplayRefreshRateFB_ = nullptr;
+  PFN_xrEnumerateDisplayRefreshRatesFB xrEnumerateDisplayRefreshRatesFB_ = nullptr;
+  PFN_xrRequestDisplayRefreshRateFB xrRequestDisplayRefreshRateFB_ = nullptr;
 
   std::unique_ptr<impl::XrAppImpl> impl_;
 

--- a/shell/openxr/src/XrApp.h
+++ b/shell/openxr/src/XrApp.h
@@ -182,6 +182,7 @@ class XrApp {
 
   bool refreshRateExtensionSupported_ = false;
   bool useMaxRefreshRate_ = false;
+  bool useSpecificRefreshRate_ = false;
   float desiredSpecificRefreshRate_ = 90.0f;
   std::vector<float> supportedRefreshRates_;
   float currentRefreshRate_ = 0.0f;


### PR DESCRIPTION

![image](https://github.com/facebook/igl/assets/11604039/53a9c3eb-5b50-4306-a366-cbb131919fc6)

Hi, I needed my OK Cloud Streamer app to run at more than the default 72 Hz, and use 90 or 120 Hz (where available, I'm testing this on Quest Pro right now but it should work fine on 120 Hz - capable headsets).

I had to change the manifests of both the GL ES and Vulkan OpenXR samples for the xrEnumerateDisplayRefreshRatesFB_ function tor return more than one refresh rate (72 Hz). While I was in there I put in support for all the features I plan on adding for various HMDs from Pico, HTC: eye-tracking, face tracking, body tracking, etc. I could remove those if you wish for this PR but I will be pushing a few more fixes I need at the IGL level so I don't have to maintain a different branch for too much longer (ideally).

Let me know if this is ok, I'll change whatever you need if the coding style or implementation has issues. But it works fine from what I see. 72 Hz shouldn't be the default for VR apps, it should be 90 Hz. And now it is.