### PR TITLE
Fix Android Studio OpenXR build on clean system

### DIFF
--- a/shell/openxr/mobile/AndroidMain.cpp
+++ b/shell/openxr/mobile/AndroidMain.cpp
@@ -14,7 +14,7 @@
 #include <unistd.h>
 #endif
 
-#include <shell/openxr/XrApp.h>
+#include <shell/openxr/src/XrApp.h>
 
 using namespace igl::shell::openxr;
 

--- a/shell/openxr/mobile/XrApp.cpp
+++ b/shell/openxr/mobile/XrApp.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <shell/openxr/XrApp.h>
+#include <shell/openxr/src/XrApp.h>
 
 #include <algorithm>
 #include <array>
@@ -44,8 +44,8 @@
 #include <shell/shared/renderSession/DefaultSession.h>
 #include <shell/shared/renderSession/ShellParams.h>
 
-#include <shell/openxr/XrLog.h>
-#include <shell/openxr/XrSwapchainProvider.h>
+#include <shell/openxr/src/XrLog.h>
+#include <shell/openxr/src/XrSwapchainProvider.h>
 #include <shell/openxr/impl/XrAppImpl.h>
 #include <shell/openxr/impl/XrSwapchainProviderImpl.h>
 

--- a/shell/openxr/mobile/vulkan/XrAppImplVulkan.cpp
+++ b/shell/openxr/mobile/vulkan/XrAppImplVulkan.cpp
@@ -7,14 +7,14 @@
 
 #include "XrAppImplVulkan.h"
 
-#include <shell/openxr/XrLog.h>
+#include <shell/openxr/src/XrLog.h>
 
 #include <igl/vulkan/Device.h>
 #include <igl/vulkan/HWDevice.h>
 #include <igl/vulkan/VulkanContext.h>
 #include <igl/vulkan/VulkanDevice.h>
 
-#include <shell/openxr/XrSwapchainProvider.h>
+#include <shell/openxr/src/XrSwapchainProvider.h>
 #include <shell/openxr/mobile/vulkan/XrSwapchainProviderImplVulkan.h>
 
 namespace igl::shell::openxr::mobile {

--- a/shell/openxr/mobile/vulkan/XrSwapchainProviderImplVulkan.cpp
+++ b/shell/openxr/mobile/vulkan/XrSwapchainProviderImplVulkan.cpp
@@ -12,7 +12,7 @@
 #include <igl/vulkan/VulkanDevice.h>
 #include <igl/vulkan/VulkanImage.h>
 #include <igl/vulkan/VulkanImageView.h>
-#include <shell/openxr/XrLog.h>
+#include <shell/openxr/src/XrLog.h>
 
 #include "XrSwapchainProviderImplVulkan.h"
 

--- a/shell/openxr/src/XrSwapchainProvider.cpp
+++ b/shell/openxr/src/XrSwapchainProvider.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "XrSwapchainProvider.h"
-#include <shell/openxr/XrLog.h>
+#include <shell/openxr/src/XrLog.h>
 #include <shell/openxr/impl/XrSwapchainProviderImpl.h>
 
 namespace igl::shell::openxr {


### PR DESCRIPTION
The OpenXR build failed to compile due to the location of certain includes being incorrect or missing.