### PR TITLE
Fix OpenXR Desktop build of IGL

### DIFF
--- a/shell/openxr/desktop/main.cpp
+++ b/shell/openxr/desktop/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, const char* argv[]) {
 // @fb-only
   // @fb-only
 #endif
-  if (!xrApp->initialize(nullptr)) {
+  if (!xrApp->initialize(nullptr, {})) {
     return 1;
   }
 


### PR DESCRIPTION
Just missing a parameter to the desktop XrApp initialize method.