### PR TITLE
Add option to override test device validation mode

### DIFF
--- a/src/igl/tests/util/device/TestDevice.cpp
+++ b/src/igl/tests/util/device/TestDevice.cpp
@@ -59,7 +59,8 @@ bool isBackendTypeSupported(::igl::BackendType backendType) {
 }
 
 std::shared_ptr<::igl::IDevice> createTestDevice(::igl::BackendType backendType,
-                                                 const std::string& backendApi) {
+                                                 const std::string& backendApi,
+                                                 bool enableValidation) {
   if (backendType == ::igl::BackendType::Metal) {
 #if IGL_METAL_SUPPORTED
     return metal::createTestDevice();
@@ -76,7 +77,7 @@ std::shared_ptr<::igl::IDevice> createTestDevice(::igl::BackendType backendType,
   }
   if (backendType == ::igl::BackendType::Vulkan) {
 #if IGL_VULKAN_SUPPORTED
-    return vulkan::createTestDevice();
+    return vulkan::createTestDevice(enableValidation);
 #else
     return nullptr;
 #endif

--- a/src/igl/tests/util/device/TestDevice.h
+++ b/src/igl/tests/util/device/TestDevice.h
@@ -27,7 +27,8 @@ bool isBackendTypeSupported(::igl::BackendType backendType);
  GLES3 context.
  */
 std::shared_ptr<::igl::IDevice> createTestDevice(::igl::BackendType backendType,
-                                                 const std::string& backendApi = "");
+                                                 const std::string& backendApi = "",
+                                                 bool enableValidation = true);
 
 } // namespace tests::util::device
 } // namespace igl

--- a/src/igl/tests/util/device/vulkan/TestDevice.cpp
+++ b/src/igl/tests/util/device/vulkan/TestDevice.cpp
@@ -28,7 +28,7 @@ namespace igl::tests::util::device::vulkan {
 //
 // Used by clients to get an IGL device.
 //
-std::shared_ptr<::igl::IDevice> createTestDevice() {
+std::shared_ptr<::igl::IDevice> createTestDevice(bool enableValidation) {
 #if IGL_PLATFORM_MACOS
   ::igl::vulkan::setupMoltenVKEnvironment();
 #endif
@@ -38,11 +38,13 @@ std::shared_ptr<::igl::IDevice> createTestDevice() {
 
   igl::vulkan::VulkanContextConfig config;
   config.enhancedShaderDebugging = false; // This causes issues for MoltenVK
+  config.enableValidation = enableValidation;
+  config.enableGPUAssistedValidation = enableValidation;
+
 #if IGL_PLATFORM_MACOS
   config.terminateOnValidationError = false;
 #elif IGL_DEBUG
-  config.enableValidation = true;
-  config.terminateOnValidationError = true;
+  config.terminateOnValidationError = enableValidation;
 #else
   config.enableValidation = false;
   config.terminateOnValidationError = false;
@@ -52,7 +54,7 @@ std::shared_ptr<::igl::IDevice> createTestDevice() {
   config.terminateOnValidationError = false;
 #endif
   config.swapChainColorSpace = igl::ColorSpace::SRGB_NONLINEAR;
-  config.enableExtraLogs = true;
+  config.enableExtraLogs = enableValidation;
 
   auto ctx = igl::vulkan::HWDevice::createContext(config, nullptr);
 

--- a/src/igl/tests/util/device/vulkan/TestDevice.h
+++ b/src/igl/tests/util/device/vulkan/TestDevice.h
@@ -16,7 +16,7 @@ namespace tests::util::device::vulkan {
 /**
  Create and return an igl::Device that is suitable for running tests against.
  */
-std::shared_ptr<::igl::IDevice> createTestDevice();
+std::shared_ptr<::igl::IDevice> createTestDevice(bool enableValidation = true);
 
 } // namespace tests::util::device::vulkan
 } // namespace igl


### PR DESCRIPTION
Summary:
This adds an extra option when creating a test device, which allows to force disable validation layer for Vulkan.

The use case is running our unit tests, that use a test device, without Vulkan SDK guaranteed to be installed (which is required for the validation layer).

Reviewed By: christophpurrer

Differential Revision: D56097688


