### PR TITLE
【Opengl】The DeviceFeatureLimits::BufferAlignment is not always equals 16 byte on OpenGL backend.

### DIFF
--- a/src/igl/opengl/DeviceFeatureSet.cpp
+++ b/src/igl/opengl/DeviceFeatureSet.cpp
@@ -1033,6 +1033,10 @@ bool DeviceFeatureSet::getFeatureLimits(DeviceFeatureLimits featureLimits, size_
     return true;
   case DeviceFeatureLimits::BufferAlignment:
     result = 16;
+    if (hasFeature(DeviceFeatures::UniformBlocks)) {
+        glContext_.getIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &tsize);
+        result = (size_t)tsize;
+    }
     return true;
   case DeviceFeatureLimits::BufferNoCopyAlignment:
     result = 0;


### PR DESCRIPTION
The DeviceFeatureLimits::BufferAlignment is not always equals 16 byte on OpenGL backend.
For example , on iOS phone is 64, on iOS simulator is 256.
So use glContext_.getIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &tsize) to get the value is better.