### PR TITLE
【Metal】The DeviceFeatureLimits::BufferAlignment is not always equals 16 byte on Metal backend

### DIFF
--- a/src/igl/metal/DeviceFeatureSet.mm
+++ b/src/igl/metal/DeviceFeatureSet.mm
@@ -247,7 +247,11 @@ bool DeviceFeatureSet::getFeatureLimits(DeviceFeatureLimits featureLimits, size_
     return true;
   case DeviceFeatureLimits::ShaderStorageBufferOffsetAlignment:
   case DeviceFeatureLimits::BufferAlignment:
+#if IGL_PLATFORM_IOS_SIMULATOR
+    result = 256;
+#else
     result = 16;
+#endif
     return true;
   case DeviceFeatureLimits::BufferNoCopyAlignment: {
     IGL_ASSERT(getpagesize() > 0);

--- a/src/igl/metal/DeviceFeatureSet.mm
+++ b/src/igl/metal/DeviceFeatureSet.mm
@@ -247,7 +247,7 @@ bool DeviceFeatureSet::getFeatureLimits(DeviceFeatureLimits featureLimits, size_
     return true;
   case DeviceFeatureLimits::ShaderStorageBufferOffsetAlignment:
   case DeviceFeatureLimits::BufferAlignment:
-#if IGL_PLATFORM_IOS_SIMULATOR
+#if (IGL_PLATFORM_IOS_SIMULATOR || IGL_PLATFORM_MACOS)
     result = 256;
 #else
     result = 16;

--- a/src/igl/metal/DeviceFeatureSet.mm
+++ b/src/igl/metal/DeviceFeatureSet.mm
@@ -247,9 +247,11 @@ bool DeviceFeatureSet::getFeatureLimits(DeviceFeatureLimits featureLimits, size_
     return true;
   case DeviceFeatureLimits::ShaderStorageBufferOffsetAlignment:
   case DeviceFeatureLimits::BufferAlignment:
-#if (IGL_PLATFORM_IOS_SIMULATOR || IGL_PLATFORM_MACOS)
+#if IGL_PLATFORM_IOS_SIMULATOR
     result = 256;
-#else
+#elif IGL_PLATFORM_MACOS
+    result = 128;
+#else   
     result = 16;
 #endif
     return true;

--- a/src/igl/metal/DeviceFeatureSet.mm
+++ b/src/igl/metal/DeviceFeatureSet.mm
@@ -247,10 +247,8 @@ bool DeviceFeatureSet::getFeatureLimits(DeviceFeatureLimits featureLimits, size_
     return true;
   case DeviceFeatureLimits::ShaderStorageBufferOffsetAlignment:
   case DeviceFeatureLimits::BufferAlignment:
-#if IGL_PLATFORM_IOS_SIMULATOR
+#if IGL_PLATFORM_IOS_SIMULATOR || IGL_PLATFORM_MACOS
     result = 256;
-#elif IGL_PLATFORM_MACOS
-    result = 128;
 #else   
     result = 16;
 #endif


### PR DESCRIPTION
The DeviceFeatureLimits::BufferAlignment is not always equals 16 byte on Metal backend.
For example , on iOS simulator is 256.

[https://developer.apple.com/documentation/metal/developing_metal_apps_that_run_in_simulator](https://developer.apple.com/documentation/metal/developing_metal_apps_that_run_in_simulator)
When you set arguments for the render or compute command, align constant buffer offsets to 256 bytes.

And I have not test the value on MacOS. Maybe it is same with iOS simulator. I cannot verify it.

From the [https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf) it shows 256B on M2.
<img width="1257" alt="image" src="https://github.com/facebook/igl/assets/7352338/1c88dcf2-0bb8-4231-80bc-4837550d702e">
