### PR TITLE
Add 'data' tag to fix lint error

### DIFF
--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/gles/AndroidManifest.xml
@@ -43,6 +43,9 @@
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https"
+              android:host="www.github.com"
+              android:pathPrefix="/facebook/igl"/>
       </intent-filter>
     </activity>
   </application>

--- a/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
+++ b/shell/openxr/mobile/java/com/facebook/igl/shell/openxr/vulkan/AndroidManifest.xml
@@ -43,6 +43,9 @@
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https"
+              android:host="www.github.com"
+              android:pathPrefix="/facebook/igl"/>
       </intent-filter>
     </activity>
   </application>


### PR DESCRIPTION
Summary: Fix failing gradle task `app:lintDebug` ("`Error: Missing data element`") when building `app-openxr-vulkan`.