### PR TITLE
fix repeat call disableVertexAttribArray()

### DIFF
--- a/src/igl/opengl/RenderPipelineState.cpp
+++ b/src/igl/opengl/RenderPipelineState.cpp
@@ -283,6 +283,8 @@ void RenderPipelineState::bindVertexAttributes(size_t bufferIndex, size_t buffer
   // attributeList and locations should have an 1-to-1 correspondence
   IGL_ASSERT(attribList.size() == locations.size());
 
+  activeAttributesLocations_.clear();
+
   for (size_t i = 0, iLen = attribList.size(); i < iLen; i++) {
     auto location = locations[i];
     if (location < 0) {


### PR DESCRIPTION
If bind RenderPipelineState once ,but call draw many times, in unbindVertexAttributes() the disableVertexAttribArray will be call many times, because activeAttributesLocations_ add items in every willDraw().