### PR TITLE
igl | OpenGL | Fix GL_DRAW_INDIRECT_BUFFER bind miss

### DIFF
--- a/src/igl/opengl/Buffer.cpp
+++ b/src/igl/opengl/Buffer.cpp
@@ -82,6 +82,8 @@ void ArrayBuffer::initialize(const BufferDesc& desc, Result* outResult) {
     target_ = GL_ARRAY_BUFFER;
   } else if (desc.type & BufferDesc::BufferTypeBits::Index) {
     target_ = GL_ELEMENT_ARRAY_BUFFER;
+  } else if (desc.type & BufferDesc::BufferTypeBits::Indirect) {
+    target_ = GL_DRAW_INDIRECT_BUFFER;
   } else {
     IGL_ASSERT_NOT_IMPLEMENTED();
   }

--- a/src/igl/opengl/Device.cpp
+++ b/src/igl/opengl/Device.cpp
@@ -37,6 +37,7 @@ std::unique_ptr<Buffer> allocateBuffer(BufferDesc::BufferType bufferType,
 
   if ((bufferType & BufferDesc::BufferTypeBits::Index) ||
       (bufferType & BufferDesc::BufferTypeBits::Vertex) ||
+      (bufferType & BufferDesc::BufferTypeBits::Indirect) ||
       (bufferType & BufferDesc::BufferTypeBits::Storage)) {
     resource = std::make_unique<ArrayBuffer>(context, requestedApiHints, bufferType);
   } else if (bufferType & BufferDesc::BufferTypeBits::Uniform) {


### PR DESCRIPTION
```c++
void RenderCommandAdapter::drawElementsIndirect(GLenum mode,
                                                GLenum indexType,
                                                Buffer& indirectBuffer,
                                                const GLvoid* indirectBufferOffset)
``` 

When I call the API above, I found that the GL_DRAW_INDIRECT_BUFFER bind miss.

This pull request is a solution.

The Another solution is https://github.com/facebook/igl/pull/128

Which is better ? 
