### PR TITLE
igl | OpenGL | Fix GL_DRAW_INDIRECT_BUFFER bind miss

### DIFF
--- a/src/igl/opengl/RenderCommandAdapter.cpp
+++ b/src/igl/opengl/RenderCommandAdapter.cpp
@@ -468,7 +468,7 @@ void RenderCommandAdapter::bindBufferWithShaderStorageBufferOverride(
     Buffer& buffer,
     GLenum overrideTargetForShaderStorageBuffer) {
   auto& arrayBuffer = static_cast<ArrayBuffer&>(buffer);
-  if (arrayBuffer.getTarget() == GL_SHADER_STORAGE_BUFFER) {
+  if (arrayBuffer.getTarget() == GL_SHADER_STORAGE_BUFFER || overrideTargetForShaderStorageBuffer == GL_DRAW_INDIRECT_BUFFER) {
     arrayBuffer.bindForTarget(overrideTargetForShaderStorageBuffer);
   } else {
     arrayBuffer.bind();


### PR DESCRIPTION
```c++
void RenderCommandAdapter::drawElementsIndirect(GLenum mode,
                                                GLenum indexType,
                                                Buffer& indirectBuffer,
                                                const GLvoid* indirectBufferOffset)
``` 

When I call the API above, I found that the GL_DRAW_INDIRECT_BUFFER bind miss.

This pull request is a solution.

The Another solution is https://github.com/facebook/igl/pull/127

Which is better ? 
