### PR TITLE
igl | github | Build only `arm64-v8a` by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ if(ANDROID)
   set(IGL_WITH_OPENGL OFF)
   set(IGL_WITH_VULKAN ON)
   set(IGL_WITH_WEBGL OFF)
+  # disable for all targets due to warnings in third-party code
+  add_definitions(-Wno-nullability-completeness)
+  add_definitions(-Wno-deprecated-volatile)
 endif()
 
 if(EMSCRIPTEN)
@@ -263,7 +266,7 @@ if(IGL_WITH_SAMPLES)
       add_subdirectory(samples/desktop)
       igl_set_folder(glfw "third-party/GLFW3")
     endif()
-    endif()
+  endif()
 endif()
 
 if (IGL_WITH_VULKAN OR IGL_WITH_IGLU OR IGL_WITH_SAMPLES)

--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -19,7 +19,9 @@ android {
         targetSdk 33
         versionCode 1
         versionName "1.0"
-
+        ndk {
+            abiFilters 'arm64-v8a'
+        }
         externalNativeBuild {
             cmake {
                 cppFlags '-std=c++17'


### PR DESCRIPTION
1) Build only `arm64-v8a` for Android due to limited space on GitHub CI
2) Disable some Android compiler warnings in third-party code