### PR TITLE
igl | opengl | fix glPushDebugGroup() & glDebugMessageInsert() miss the last letter in the label.

### DIFF
--- a/src/igl/opengl/CommandBuffer.cpp
+++ b/src/igl/opengl/CommandBuffer.cpp
@@ -46,8 +46,7 @@ void CommandBuffer::waitUntilCompleted() {
 void CommandBuffer::pushDebugGroupLabel(const char* label, const igl::Color& /*color*/) const {
   IGL_ASSERT(label != nullptr && *label);
   if (getContext().deviceFeatures().hasInternalFeature(InternalFeatures::DebugMessage)) {
-    const std::string_view labelSV(label);
-    getContext().pushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, labelSV.length(), labelSV.data());
+    getContext().pushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, label);
   } else {
     IGL_LOG_ERROR_ONCE("CommandBuffer::pushDebugGroupLabel not supported in this context!\n");
   }

--- a/src/igl/opengl/ComputeCommandEncoder.cpp
+++ b/src/igl/opengl/ComputeCommandEncoder.cpp
@@ -64,8 +64,7 @@ void ComputeCommandEncoder::pushDebugGroupLabel(const char* label,
                                                 const igl::Color& /*color*/) const {
   IGL_ASSERT(label != nullptr && *label);
   if (getContext().deviceFeatures().hasInternalFeature(InternalFeatures::DebugMessage)) {
-    const std::string_view labelSV(label);
-    getContext().pushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, labelSV.length(), labelSV.data());
+    getContext().pushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, label);
   } else {
     IGL_LOG_ERROR_ONCE(
         "ComputeCommandEncoder::pushDebugGroupLabel not supported in this context!\n");
@@ -76,13 +75,12 @@ void ComputeCommandEncoder::insertDebugEventLabel(const char* label,
                                                   const igl::Color& /*color*/) const {
   IGL_ASSERT(label != nullptr && *label);
   if (getContext().deviceFeatures().hasInternalFeature(InternalFeatures::DebugMessage)) {
-    const std::string_view labelSV(label);
     getContext().debugMessageInsert(GL_DEBUG_SOURCE_APPLICATION,
                                     GL_DEBUG_TYPE_MARKER,
                                     0,
                                     GL_DEBUG_SEVERITY_LOW,
-                                    labelSV.length(),
-                                    labelSV.data());
+                                    -1,
+                                    label);
   } else {
     IGL_LOG_ERROR_ONCE(
         "ComputeCommandEncoder::insertDebugEventLabel not supported in this context!\n");

--- a/src/igl/opengl/RenderCommandEncoder.cpp
+++ b/src/igl/opengl/RenderCommandEncoder.cpp
@@ -193,8 +193,7 @@ void RenderCommandEncoder::pushDebugGroupLabel(const char* label,
   IGL_ASSERT(adapter_);
   IGL_ASSERT(label != nullptr && *label);
   if (getContext().deviceFeatures().hasInternalFeature(InternalFeatures::DebugMessage)) {
-    const std::string_view labelSV(label);
-    getContext().pushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, labelSV.length(), labelSV.data());
+    getContext().pushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, label);
   } else {
     IGL_LOG_ERROR_ONCE(
         "RenderCommandEncoder::pushDebugGroupLabel not supported in this context!\n");
@@ -206,13 +205,12 @@ void RenderCommandEncoder::insertDebugEventLabel(const char* label,
   IGL_ASSERT(adapter_);
   IGL_ASSERT(label != nullptr && *label);
   if (getContext().deviceFeatures().hasInternalFeature(InternalFeatures::DebugMessage)) {
-    const std::string_view labelSV(label);
     getContext().debugMessageInsert(GL_DEBUG_SOURCE_APPLICATION,
                                     GL_DEBUG_TYPE_MARKER,
                                     0,
                                     GL_DEBUG_SEVERITY_LOW,
-                                    labelSV.length(),
-                                    labelSV.data());
+                                    -1,
+                                    label);
   } else {
     IGL_LOG_ERROR_ONCE(
         "RenderCommandEncoder::insertDebugEventLabel not supported in this context!\n");


### PR DESCRIPTION
The last letter in the label is missing currently.

```
void glPushDebugGroup( GLenum source,GLuint id,GLsizei length,const char * message);
```     

From the khronos's document : If length is negative, it is implied that message contains a null terminated string.

https://registry.khronos.org/OpenGL-Refpages/gl4/html/glPushDebugGroup.xhtml
https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDebugMessageInsert.xhtml