### PR TITLE
igl | OpenGL | fix confused the difference between StencilReference and readMask

### DIFF
--- a/src/igl/opengl/DepthStencilState.cpp
+++ b/src/igl/opengl/DepthStencilState.cpp
@@ -43,15 +43,6 @@ GLenum DepthStencilState::convertCompareFunction(igl::CompareFunction value) {
   IGL_UNREACHABLE_RETURN(GL_ALWAYS)
 }
 
-void DepthStencilState::setStencilReferenceValue(uint32_t value) {
-  desc_.backFaceStencil.readMask = desc_.frontFaceStencil.readMask = value;
-}
-
-void DepthStencilState::setStencilReferenceValues(uint32_t frontValue, uint32_t backValue) {
-  desc_.backFaceStencil.readMask = backValue;
-  desc_.frontFaceStencil.readMask = frontValue;
-}
-
 GLenum DepthStencilState::convertStencilOperation(igl::StencilOperation value) {
   switch (value) {
   case StencilOperation::Keep:
@@ -74,7 +65,7 @@ GLenum DepthStencilState::convertStencilOperation(igl::StencilOperation value) {
   IGL_UNREACHABLE_RETURN(GL_ZERO)
 }
 
-void DepthStencilState::bind() {
+void DepthStencilState::bind(uint32_t frontStencilReferenceValue, uint32_t backStencilReferenceValue) {
   getContext().depthMask(static_cast<GLboolean>(desc_.isDepthWriteEnabled));
 
   // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthFunc.xhtml
@@ -91,15 +82,14 @@ void DepthStencilState::bind() {
       desc_.backFaceStencil != igl::StencilStateDesc()) {
     getContext().enable(GL_STENCIL_TEST);
 
-    const GLuint mask{0xff};
     const GLenum frontCompareFunc =
         convertCompareFunction(desc_.frontFaceStencil.stencilCompareFunction);
     const GLenum backCompareFunc =
         convertCompareFunction(desc_.backFaceStencil.stencilCompareFunction);
     getContext().stencilFuncSeparate(
-        GL_FRONT, frontCompareFunc, desc_.frontFaceStencil.readMask, mask);
+        GL_FRONT, frontCompareFunc, frontStencilReferenceValue, desc_.frontFaceStencil.readMask);
     getContext().stencilFuncSeparate(
-        GL_BACK, backCompareFunc, desc_.backFaceStencil.readMask, mask);
+        GL_BACK, backCompareFunc, backStencilReferenceValue, desc_.backFaceStencil.readMask);
 
     GLenum sfail = convertStencilOperation(desc_.backFaceStencil.stencilFailureOperation);
     GLenum dpfail = convertStencilOperation(desc_.backFaceStencil.depthFailureOperation);

--- a/src/igl/opengl/DepthStencilState.h
+++ b/src/igl/opengl/DepthStencilState.h
@@ -25,14 +25,11 @@ class DepthStencilState final : public WithContext, public IDepthStencilState {
   ~DepthStencilState() override = default;
 
   Result create(const DepthStencilStateDesc& desc);
-  void bind();
+  void bind(uint32_t frontStencilReferenceValue, uint32_t backStencilReferenceValue);
   void unbind();
 
   static GLenum convertCompareFunction(igl::CompareFunction value);
   static GLenum convertStencilOperation(igl::StencilOperation value);
-
-  void setStencilReferenceValue(uint32_t value);
-  void setStencilReferenceValues(uint32_t frontValue, uint32_t backValue);
 
  private:
   DepthStencilStateDesc desc_;

--- a/src/igl/opengl/RenderCommandAdapter.cpp
+++ b/src/igl/opengl/RenderCommandAdapter.cpp
@@ -91,12 +91,9 @@ void RenderCommandAdapter::setDepthStencilState(
 }
 
 void RenderCommandAdapter::setStencilReferenceValue(uint32_t value, Result* outResult) {
-  if (!IGL_VERIFY(depthStencilState_)) {
-    Result::setResult(outResult, Result::Code::InvalidOperation, "depth stencil state is null");
-    return;
-  }
-  auto& depthStencilState = static_cast<DepthStencilState&>(*depthStencilState_);
-  depthStencilState.setStencilReferenceValue(value);
+  frontStencilReferenceValue_ = value;
+  backStencilReferenceValue_ = value;
+    
   setDirty(StateMask::DEPTH_STENCIL);
   Result::setOk(outResult);
 }
@@ -104,12 +101,8 @@ void RenderCommandAdapter::setStencilReferenceValue(uint32_t value, Result* outR
 void RenderCommandAdapter::setStencilReferenceValues(uint32_t frontValue,
                                                      uint32_t backValue,
                                                      Result* outResult) {
-  if (!IGL_VERIFY(depthStencilState_)) {
-    Result::setResult(outResult, Result::Code::InvalidOperation, "depth stencil state is null");
-    return;
-  }
-  auto& depthStencilState = static_cast<DepthStencilState&>(*depthStencilState_);
-  depthStencilState.setStencilReferenceValues(frontValue, backValue);
+  frontStencilReferenceValue_ = frontValue;
+  backStencilReferenceValue_ = backValue;
   setDirty(StateMask::DEPTH_STENCIL);
   Result::setOk(outResult);
 }
@@ -372,7 +365,7 @@ void RenderCommandAdapter::willDraw() {
 
   auto* depthStencilState = static_cast<DepthStencilState*>(depthStencilState_.get());
   if (depthStencilState && isDirty(StateMask::DEPTH_STENCIL)) {
-    depthStencilState->bind();
+    depthStencilState->bind(frontStencilReferenceValue_, backStencilReferenceValue_);
     clearDirty(StateMask::DEPTH_STENCIL);
   }
 

--- a/src/igl/opengl/RenderCommandAdapter.h
+++ b/src/igl/opengl/RenderCommandAdapter.h
@@ -157,6 +157,8 @@ class RenderCommandAdapter final : public WithContext {
   std::shared_ptr<IRenderPipelineState> pipelineState_;
   std::shared_ptr<IDepthStencilState> depthStencilState_;
   std::shared_ptr<VertexArrayObject> activeVAO_ = nullptr;
+  uint32_t frontStencilReferenceValue_ = 0;
+  uint32_t backStencilReferenceValue_ = 0;
 
   UnbindPolicy cachedUnbindPolicy_;
   bool useVAO_ = false;

--- a/src/igl/tests/ogl/DepthStencilState.cpp
+++ b/src/igl/tests/ogl/DepthStencilState.cpp
@@ -164,7 +164,7 @@ TEST_F(DepthStencilStateTest, Passthrough) {
   // No asserts, just test the passthroughs are successful
   cmdEncoder->bindDepthStencilState(idss);
   auto dss = std::static_pointer_cast<igl::opengl::DepthStencilState>(idss);
-  dss->bind(); // Test bind passthrough
+  dss->bind(0,0); // Test bind passthrough
   dss->unbind();
 }
 


### PR DESCRIPTION
```
void glStencilFuncSeparate(	
        GLenum face,
 	GLenum func,
 	GLint ref,
 	GLuint mask);
```
https://registry.khronos.org/OpenGL-Refpages/gl4/html/glStencilFuncSeparate.xhtml

The third param is StencilReference, and the last param is mask.

And in the API design, StencilReference is independent with readMask/writeMask.


