### PR TITLE
igl | Vulkan | Fix later StencilStateDesc miss

### DIFF
--- a/src/igl/vulkan/RenderCommandEncoder.cpp
+++ b/src/igl/vulkan/RenderCommandEncoder.cpp
@@ -419,10 +419,6 @@ void RenderCommandEncoder::bindDepthStencilState(
   dynamicState_.setDepthCompareOp(compareFunctionToVkCompareOp(desc.compareFunction));
 
   auto setStencilState = [this](VkStencilFaceFlagBits faceMask, const igl::StencilStateDesc& desc) {
-    if (desc == igl::StencilStateDesc()) {
-      // do not update anything if we don't have an actual state
-      return;
-    }
     dynamicState_.setStencilStateOps(faceMask == VK_STENCIL_FACE_FRONT_BIT,
                                      stencilOperationToVkStencilOp(desc.stencilFailureOperation),
                                      stencilOperationToVkStencilOp(desc.depthStencilPassOperation),


### PR DESCRIPTION
When use the same RenderCommandEncoder multiple times within a frame, binding the stencil test state multiple times, and performing multiple draws, if the later stencil test state descriptor is the same as the default StencilStateDesc, the stencil test state will not be reset.