### PR TITLE
igl | shell | Fix EGL_BAD_SURFACE error when adding DeviceScope for TinyRenderer::onSurfacesChanged().

### DIFF
--- a/shell/android/jni/TinyRenderer.cpp
+++ b/shell/android/jni/TinyRenderer.cpp
@@ -147,8 +147,6 @@ void TinyRenderer::render(float displayScale) {
 }
 
 void TinyRenderer::onSurfacesChanged(ANativeWindow* /*surface*/, int width, int height) {
-  igl::DeviceScope const scope(platform_->getDevice());
-
   width_ = static_cast<uint32_t>(width);
   height_ = static_cast<uint32_t>(height);
 #if IGL_BACKEND_OPENGL


### PR DESCRIPTION
This issue was caused by https://github.com/facebook/igl/commit/b9488f5851463dc598eeb39e39df3d1936fd9207

This problem occurs when the app is switched to the background.

<img width="1872" alt="企业微信截图_0ac4cef3-1c51-45f5-985e-4a73e2e568e3" src="https://github.com/user-attachments/assets/3b71a0e3-154c-4334-a14c-a26691c9cd97">
