### PR TITLE
igl | vulkan | Disable dualSrcBlend on Android.

### DIFF
--- a/shell/android/jni/TinyRenderer.cpp
+++ b/shell/android/jni/TinyRenderer.cpp
@@ -72,13 +72,22 @@ void TinyRenderer::init(AAssetManager* mgr,
     IGL_ASSERT(result.isOk());
     width_ = static_cast<uint32_t>(ANativeWindow_getWidth(nativeWindow));
     height_ = static_cast<uint32_t>(ANativeWindow_getHeight(nativeWindow));
+
+    // https://github.com/gpuweb/gpuweb/issues/4283
+    // Only 49.5% of Android devices support dualSrcBlend.
+    // Android devices that do not support dualSrcBlend primarily use ARM, ImgTec, and Qualcomm GPUs.
+    // https://vulkan.gpuinfo.org/listdevicescoverage.php?feature=dualSrcBlend&platform=android&option=not
+    igl::vulkan::VulkanFeatures vulkanFeatures(VK_API_VERSION_1_1, config);
+    vulkanFeatures.enableDefaultFeatures1_1();
+    vulkanFeatures.VkPhysicalDeviceFeatures2_.features.dualSrcBlend = VK_FALSE;
+
     d = vulkan::HWDevice::create(std::move(ctx),
                                  devices[0],
                                  width_, // width
                                  height_, // height,,
                                  0,
                                  nullptr,
-                                 nullptr,
+                                 &vulkanFeatures,
                                  &result);
     break;
   }

--- a/src/igl/vulkan/VulkanFeatures.cpp
+++ b/src/igl/vulkan/VulkanFeatures.cpp
@@ -27,7 +27,9 @@ void VulkanFeatures::populateWithAvailablePhysicalDeviceFeatures(
 
 void VulkanFeatures::enableDefaultFeatures1_1() noexcept {
   auto& features = VkPhysicalDeviceFeatures2_.features;
+#if !IGL_PLATFORM_ANDROID
   features.dualSrcBlend = VK_TRUE;
+#endif
   features.shaderInt16 = VK_TRUE;
   features.multiDrawIndirect = VK_TRUE;
   features.drawIndirectFirstInstance = VK_TRUE;

--- a/src/igl/vulkan/VulkanFeatures.cpp
+++ b/src/igl/vulkan/VulkanFeatures.cpp
@@ -27,9 +27,7 @@ void VulkanFeatures::populateWithAvailablePhysicalDeviceFeatures(
 
 void VulkanFeatures::enableDefaultFeatures1_1() noexcept {
   auto& features = VkPhysicalDeviceFeatures2_.features;
-#if !IGL_PLATFORM_ANDROID
   features.dualSrcBlend = VK_TRUE;
-#endif
   features.shaderInt16 = VK_TRUE;
   features.multiDrawIndirect = VK_TRUE;
   features.drawIndirectFirstInstance = VK_TRUE;


### PR DESCRIPTION
Reference from : https://github.com/gpuweb/gpuweb/issues/4283

The dualSrcBlend feature is available on 72.6% of devices. This feature is overwhelmingly supported on Windows, Linux, MacOS and iOS devices, however, only 49.5% of Android devices have support. Android devices that do not support dualSrcBlend primarily use ARM, ImgTec, and Qualcomm GPUs.https://vulkan.gpuinfo.org/listdevicescoverage.php?feature=dualSrcBlend&platform=android&option=not