### PR TITLE
Populate glInternalFormat when creating OpenGL texture as externally managed

### DIFF
--- a/src/igl/opengl/PlatformDevice.cpp
+++ b/src/igl/opengl/PlatformDevice.cpp
@@ -43,9 +43,8 @@ std::unique_ptr<TextureBufferExternal> PlatformDevice::createTextureBufferExtern
     GLsizei height,
     TextureFormat format,
     GLsizei numLayers) const {
-  auto textureBuffer = std::make_unique<TextureBufferExternal>(getContext(), format);
+  auto textureBuffer = std::make_unique<TextureBufferExternal>(getContext(), format, usage);
   textureBuffer->setTextureBufferProperties(textureID, target);
-  textureBuffer->setUsage(usage);
   textureBuffer->setTextureProperties(width, height, numLayers);
   if (auto resourceTracker = owner_.getResourceTracker()) {
     textureBuffer->initResourceTracker(resourceTracker);

--- a/src/igl/opengl/TextureBufferExternal.cpp
+++ b/src/igl/opengl/TextureBufferExternal.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <igl/opengl/TextureBufferExternal.h>
+
+namespace igl::opengl {
+TextureBufferExternal::TextureBufferExternal(IContext& context,
+                                             TextureFormat format,
+                                             TextureDesc::TextureUsage usage) :
+  Super(context, format) {
+  FormatDescGL formatDescGL;
+  toFormatDescGL(format, usage, formatDescGL);
+  glInternalFormat_ = formatDescGL.internalFormat;
+
+  setUsage(usage);
+}
+
+} // namespace igl::opengl

--- a/src/igl/opengl/TextureBufferExternal.h
+++ b/src/igl/opengl/TextureBufferExternal.h
@@ -18,8 +18,9 @@ class TextureBufferExternal : public TextureBufferBase {
   friend class PlatformDevice; // So that PlatformDevice can do setTextureBufferProperties
 
  public:
-  explicit TextureBufferExternal(IContext& context, TextureFormat format) :
-    Super(context, format) {}
+  explicit TextureBufferExternal(IContext& context,
+                                 TextureFormat format,
+                                 TextureDesc::TextureUsage usage);
   ~TextureBufferExternal() override = default;
 
   [[nodiscard]] bool supportsUpload() const final {


### PR DESCRIPTION
Summary:
If creating `TextureBuffer` via `createTextureBufferExternal`, the `glInternalFormat_` wasn't correctly populated (remaining at 0), violating the internal consistency of the corresponding Texture object.

When tried to be used later by a client with OpenGL ES backend, this would assert in `getGLInternalTextureFormat` because of that.

This diff correspondingly makes sure that if we use ` createTextureBufferExternal` then `glInternalFormat_` is set to whatever value corresponds to that externally managed texture.

Differential Revision: D61905498
