### PR TITLE
igl | Add API getResourceName() for ITrackedResource

### DIFF
--- a/src/igl/ITrackedResource.h
+++ b/src/igl/ITrackedResource.h
@@ -33,14 +33,17 @@ class ITrackedResource {
    * @brief initResourceTracker() sets up tracking with the tracker
    * When the resource is destroyed, it will automatically deregister itself with the tracker
    */
-  void initResourceTracker(std::shared_ptr<IResourceTracker> tracker) {
+  void initResourceTracker(std::shared_ptr<IResourceTracker> tracker, const std::string & name = "") {
     if (IGL_VERIFY(!resourceTracker_)) {
       resourceTracker_ = std::move(tracker);
+      resourceName_ = name;
       if (resourceTracker_) {
         resourceTracker_->didCreate(static_cast<T*>(this));
       }
     }
   }
+    
+  virtual const std::string & getResourceName() const { return resourceName_;}
 
  private:
   // ITrackedResource destructor is called after the `T` object is partially destructed
@@ -61,6 +64,7 @@ class ITrackedResource {
   }
 
   std::shared_ptr<IResourceTracker> resourceTracker_;
+  std::string resourceName_;
 };
 
 } // namespace igl

--- a/src/igl/Shader.cpp
+++ b/src/igl/Shader.cpp
@@ -197,6 +197,7 @@ ShaderStagesDesc ShaderStagesDesc::fromRenderModules(
     std::shared_ptr<IShaderModule> vertexModule,
     std::shared_ptr<IShaderModule> fragmentModule) {
   ShaderStagesDesc desc;
+  desc.debugName = vertexModule->info().debugName + ", " + fragmentModule->info().debugName;
   desc.type = ShaderStagesType::Render;
   desc.vertexModule = std::move(vertexModule);
   desc.fragmentModule = std::move(fragmentModule);
@@ -205,6 +206,7 @@ ShaderStagesDesc ShaderStagesDesc::fromRenderModules(
 
 ShaderStagesDesc ShaderStagesDesc::fromComputeModule(std::shared_ptr<IShaderModule> computeModule) {
   ShaderStagesDesc desc;
+  desc.debugName = computeModule->info().debugName;
   desc.type = ShaderStagesType::Compute;
   desc.computeModule = std::move(computeModule);
   return desc;

--- a/src/igl/Shader.h
+++ b/src/igl/Shader.h
@@ -46,6 +46,8 @@ struct ShaderModuleInfo {
   ShaderStage stage = ShaderStage::Fragment;
   /** @brief The module's entry point. */
   std::string entryPoint;
+    
+  std::string debugName;
 
   bool operator==(const ShaderModuleInfo& other) const;
   bool operator!=(const ShaderModuleInfo& other) const;
@@ -263,6 +265,9 @@ struct ShaderStagesDesc {
   std::shared_ptr<IShaderModule> computeModule;
   /** @brief The type of shader stages: render or compute. */
   ShaderStagesType type = ShaderStagesType::Render;
+    
+  /** @brief Identifier used for debugging */
+  std::string debugName;
 };
 
 /**

--- a/src/igl/metal/PlatformDevice.mm
+++ b/src/igl/metal/PlatformDevice.mm
@@ -50,7 +50,7 @@ std::shared_ptr<SamplerState> PlatformDevice::createSamplerState(const SamplerSt
   id<MTLSamplerState> metalObject = [device_.get() newSamplerStateWithDescriptor:metalDesc];
   auto resource = std::make_shared<SamplerState>(metalObject);
   if (device_.getResourceTracker()) {
-    resource->initResourceTracker(device_.getResourceTracker());
+    resource->initResourceTracker(device_.getResourceTracker(), desc.debugName);
   }
   Result::setOk(outResult);
   return resource;

--- a/src/igl/metal/ios/Device.mm
+++ b/src/igl/metal/ios/Device.mm
@@ -17,7 +17,7 @@ std::shared_ptr<IFramebuffer> Device::createFramebuffer(const FramebufferDesc& d
                                                         Result* outResult) {
   auto resource = std::make_shared<Framebuffer>(desc);
   if (getResourceTracker()) {
-    resource->initResourceTracker(getResourceTracker());
+    resource->initResourceTracker(getResourceTracker(), desc.debugName);
   }
   Result::setOk(outResult);
   return resource;

--- a/src/igl/opengl/Device.cpp
+++ b/src/igl/opengl/Device.cpp
@@ -137,7 +137,7 @@ std::unique_ptr<IBuffer> Device::createBuffer(const BufferDesc& desc,
   if (resource) {
     resource->initialize(desc, outResult);
     if (getResourceTracker()) {
-      resource->initResourceTracker(getResourceTracker());
+      resource->initResourceTracker(getResourceTracker(), desc.debugName);
     }
   } else {
     Result::setResult(outResult, Result::Code::RuntimeError, "Could not instantiate buffer.");
@@ -156,7 +156,7 @@ std::shared_ptr<ISamplerState> Device::createSamplerState(const SamplerStateDesc
                                                           Result* outResult) const {
   auto resource = std::make_shared<SamplerState>(getContext(), desc);
   if (getResourceTracker()) {
-    resource->initResourceTracker(getResourceTracker());
+    resource->initResourceTracker(getResourceTracker(), desc.debugName);
   }
   Result::setOk(outResult);
   return resource;
@@ -198,7 +198,7 @@ std::shared_ptr<ITexture> Device::createTexture(const TextureDesc& desc,
     if (!result.isOk()) {
       texture = nullptr;
     } else if (getResourceTracker()) {
-      texture->initResourceTracker(getResourceTracker());
+      texture->initResourceTracker(getResourceTracker(), desc.debugName);
     }
 
     Result::setResult(outResult, std::move(result));
@@ -246,7 +246,7 @@ std::shared_ptr<IShaderModule> Device::createShaderModule(const ShaderModuleDesc
                                                           Result* outResult) const {
   auto sm = createSharedResource<ShaderModule>(desc, outResult, getContext(), desc.info);
   if (auto resourceTracker = getResourceTracker(); sm && resourceTracker) {
-    sm->initResourceTracker(resourceTracker);
+    sm->initResourceTracker(resourceTracker, desc.debugName);
   }
   return sm;
 }
@@ -258,7 +258,7 @@ std::unique_ptr<IShaderStages> Device::createShaderStages(const ShaderStagesDesc
   // The second instance is so it also gets passed to the ShaderStages constructor.
   auto stages = createUniqueResource<ShaderStages>(desc, outResult, desc, getContext());
   if (auto resourceTracker = getResourceTracker(); stages && resourceTracker) {
-    stages->initResourceTracker(resourceTracker);
+    stages->initResourceTracker(resourceTracker, desc.debugName);
   }
   return stages;
 }

--- a/src/igl/opengl/PlatformDevice.cpp
+++ b/src/igl/opengl/PlatformDevice.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<Framebuffer> PlatformDevice::createFramebuffer(const Framebuffer
   auto resource = std::make_shared<CustomFramebuffer>(getContext());
   resource->initialize(desc, outResult);
   if (auto resourceTracker = owner_.getResourceTracker()) {
-    resource->initResourceTracker(resourceTracker);
+    resource->initResourceTracker(resourceTracker, desc.debugName);
   }
   return resource;
 }


### PR DESCRIPTION
Motivation: When tracking ITrackedResource, having only a pointer is not sufficient. By adding a name, it becomes more convenient to track which resource is being created or deleted. The default name can be empty, and it won't affect the existing API.