### PR TITLE
igl | opengl | The glUniformBlockBinding() function only needs to be called once for each program

### DIFF
--- a/src/igl/opengl/RenderPipelineState.cpp
+++ b/src/igl/opengl/RenderPipelineState.cpp
@@ -220,10 +220,13 @@ void RenderPipelineState::bind() {
   if (desc_.shaderStages) {
     const auto& shaderStages = std::static_pointer_cast<ShaderStages>(desc_.shaderStages);
     shaderStages->bind();
-    for (const auto& binding : uniformBlockBindingMap_) {
-      const auto& blockIndex = binding.first;
-      const auto& bindingIndex = binding.second;
-      getContext().uniformBlockBinding(shaderStages->getProgramID(), blockIndex, bindingIndex);
+    if (!hasLinkUniformBlockBindingPoint_){
+      for (const auto& binding : uniformBlockBindingMap_) {
+        const auto& blockIndex = binding.first;
+        const auto& bindingIndex = binding.second;
+        getContext().uniformBlockBinding(shaderStages->getProgramID(), blockIndex, bindingIndex);
+      }
+      hasLinkUniformBlockBindingPoint_ = true;
     }
   }
 

--- a/src/igl/opengl/RenderPipelineState.cpp
+++ b/src/igl/opengl/RenderPipelineState.cpp
@@ -220,13 +220,13 @@ void RenderPipelineState::bind() {
   if (desc_.shaderStages) {
     const auto& shaderStages = std::static_pointer_cast<ShaderStages>(desc_.shaderStages);
     shaderStages->bind();
-    if (!hasLinkUniformBlockBindingPoint_){
+    if (!uniformBlockBindingPointSet_){
       for (const auto& binding : uniformBlockBindingMap_) {
         const auto& blockIndex = binding.first;
         const auto& bindingIndex = binding.second;
         getContext().uniformBlockBinding(shaderStages->getProgramID(), blockIndex, bindingIndex);
       }
-      hasLinkUniformBlockBindingPoint_ = true;
+      uniformBlockBindingPointSet_ = true;
     }
   }
 
@@ -390,10 +390,6 @@ void RenderPipelineState::setRenderPipelineReflection(
     const IRenderPipelineReflection& renderPipelineReflection) {
   IGL_DEBUG_ASSERT_NOT_IMPLEMENTED();
   (void)renderPipelineReflection;
-}
-
-std::unordered_map<int, size_t>& RenderPipelineState::uniformBlockBindingMap() {
-  return uniformBlockBindingMap_;
 }
 
 } // namespace igl::opengl

--- a/src/igl/opengl/RenderPipelineState.h
+++ b/src/igl/opengl/RenderPipelineState.h
@@ -69,8 +69,6 @@ class RenderPipelineState final : public WithContext, public IRenderPipelineStat
     return desc_.polygonFillMode;
   }
 
-  std::unordered_map<int, size_t>& uniformBlockBindingMap();
-
   const ShaderStages* getShaderStages() const {
     return static_cast<ShaderStages*>(desc_.shaderStages.get());
   }
@@ -87,7 +85,7 @@ class RenderPipelineState final : public WithContext, public IRenderPipelineStat
   std::vector<int> activeAttributesLocations_;
   BlendMode blendMode_ = {GL_FUNC_ADD, GL_FUNC_ADD, GL_ONE, GL_ZERO, GL_ONE, GL_ZERO};
   bool blendEnabled_ = false;
-  bool hasLinkUniformBlockBindingPoint_ = false;
+  bool uniformBlockBindingPointSet_ = false;
 };
 
 } // namespace igl::opengl

--- a/src/igl/opengl/RenderPipelineState.h
+++ b/src/igl/opengl/RenderPipelineState.h
@@ -87,6 +87,7 @@ class RenderPipelineState final : public WithContext, public IRenderPipelineStat
   std::vector<int> activeAttributesLocations_;
   BlendMode blendMode_ = {GL_FUNC_ADD, GL_FUNC_ADD, GL_ONE, GL_ZERO, GL_ONE, GL_ZERO};
   bool blendEnabled_ = false;
+  bool hasLinkUniformBlockBindingPoint_ = false;
 };
 
 } // namespace igl::opengl


### PR DESCRIPTION
The glUniformBlockBinding() function only needs to be called once for each program and does not need to be called every frame.