### PR TITLE
igl | shell | iOS | Fix OpenGLView drawable color format.

### DIFF
--- a/shell/ios/ViewController.mm
+++ b/shell/ios/ViewController.mm
@@ -186,6 +186,25 @@
 #if IGL_BACKEND_OPENGL
     auto openGLView = [[OpenGLView alloc] initWithTouchDelegate:self];
     openGLView.viewSizeChangeDelegate = self;
+      
+    NSString * drawablePropertyColorFormat = kEAGLColorFormatRGBA8;
+
+    switch (config_.colorFramebufferFormat) {
+          case igl::TextureFormat::BGRA_UNorm8:
+              drawablePropertyColorFormat = kEAGLColorFormatRGBA8;
+              break;
+              
+          case igl::TextureFormat::BGRA_SRGB:
+              drawablePropertyColorFormat = kEAGLColorFormatSRGBA8;
+              break;
+              
+          default:
+              break;
+    }
+      
+    ((CAEAGLLayer *)openGLView.layer).drawableProperties = [NSDictionary dictionaryWithObjectsAndKeys:
+                                                            drawablePropertyColorFormat,kEAGLDrawablePropertyColorFormat,
+                                                            nil];
     self.view = openGLView;
 #endif
     break;


### PR DESCRIPTION
Fix inconsistent texture colors between OpenGL and Metal

<img width="328" alt="企业微信截图_e408949d-60df-4d7b-ac01-7a6530d82888" src="https://github.com/user-attachments/assets/a85394c6-9963-4e10-a102-3daaade398dd">
 |
<img width="328" alt="企业微信截图_ab20610e-492d-4e95-ae77-8c776b005648" src="https://github.com/user-attachments/assets/2db1a4a1-a5fa-436f-9111-aff2c94a1d36">
