### PR TITLE
igl | opengl | glBindBufferRange() use the precise size.

### DIFF
--- a/src/igl/opengl/Buffer.cpp
+++ b/src/igl/opengl/Buffer.cpp
@@ -217,7 +217,7 @@ void UniformBlockBuffer::bindRange(size_t index, size_t offset, size_t size, Res
     IGL_DEBUG_ASSERT(
         (offset + size) <= getSizeInBytes(), "Offset or Size is invalid! (%d %d %d)", offset, size, getSizeInBytes());
     getContext().bindBufferRange(
-        target_, (GLuint)index, iD_, (GLintptr)offset, (GLsizeiptr)(size > 0 ? size : getSizeInBytes() - offset));
+        target_, (GLuint)index, iD_, (GLintptr)offset, (size > 0 ? size : getSizeInBytes() - offset));
     Result::setOk(outResult);
   } else {
     static const char* kErrorMsg = "Uniform Blocks are not supported";

--- a/src/igl/opengl/Buffer.cpp
+++ b/src/igl/opengl/Buffer.cpp
@@ -205,7 +205,7 @@ void UniformBlockBuffer::bindBase(size_t index, Result* outResult) {
   }
 }
 
-void UniformBlockBuffer::bindRange(size_t index, size_t offset, Result* outResult) {
+void UniformBlockBuffer::bindRange(size_t index, size_t offset, size_t size, Result* outResult) {
   if (getContext().deviceFeatures().hasFeature(DeviceFeatures::UniformBlocks)) {
     if (target_ != GL_UNIFORM_BUFFER) {
       static const char* kErrorMsg = "Buffer should be GL_UNIFORM_BUFFER";
@@ -215,9 +215,9 @@ void UniformBlockBuffer::bindRange(size_t index, size_t offset, Result* outResul
     }
     getContext().bindBuffer(target_, iD_);
     IGL_DEBUG_ASSERT(
-        offset < getSizeInBytes(), "Offset is invalid! (%d %d)", offset, getSizeInBytes());
+        (offset + size) <= getSizeInBytes(), "Offset or Size is invalid! (%d %d %d)", offset, size, getSizeInBytes());
     getContext().bindBufferRange(
-        target_, (GLuint)index, iD_, (GLintptr)offset, getSizeInBytes() - offset);
+        target_, (GLuint)index, iD_, (GLintptr)offset, (GLsizeiptr)(size > 0 ? size : getSizeInBytes() - offset));
     Result::setOk(outResult);
   } else {
     static const char* kErrorMsg = "Uniform Blocks are not supported";

--- a/src/igl/opengl/Buffer.h
+++ b/src/igl/opengl/Buffer.h
@@ -118,7 +118,7 @@ class UniformBlockBuffer : public ArrayBuffer {
 
   void setBlockBinding(GLuint pid, GLuint blockIndex, GLuint bindingPoint);
   void bindBase(size_t index, Result* outResult);
-  void bindRange(size_t index, size_t offset, Result* outResult);
+  void bindRange(size_t index, size_t offset, size_t size, Result* outResult);
 
   [[nodiscard]] BufferDesc::BufferAPIHint acceptedApiHints() const noexcept override {
     return BufferDesc::BufferAPIHintBits::UniformBlock;

--- a/src/igl/opengl/ComputeCommandAdapter.cpp
+++ b/src/igl/opengl/ComputeCommandAdapter.cpp
@@ -67,9 +67,10 @@ void ComputeCommandAdapter::setUniform(const UniformDesc& uniformDesc,
 
 void ComputeCommandAdapter::setBlockUniform(Buffer* buffer,
                                             size_t offset,
+                                            size_t size,
                                             int index,
                                             Result* outResult) {
-  uniformAdapter_.setUniformBuffer(buffer, offset, index, outResult);
+  uniformAdapter_.setUniformBuffer(buffer, offset, size, index, outResult);
 }
 
 void ComputeCommandAdapter::dispatchThreadGroups(const Dimensions& threadgroupCount,

--- a/src/igl/opengl/ComputeCommandAdapter.h
+++ b/src/igl/opengl/ComputeCommandAdapter.h
@@ -49,7 +49,7 @@ class ComputeCommandAdapter final : public WithContext {
   void setBuffer(Buffer* buffer, size_t offset, uint32_t index);
 
   void clearUniformBuffers();
-  void setBlockUniform(Buffer* buffer, size_t offset, int index, Result* outResult = nullptr);
+  void setBlockUniform(Buffer* buffer, size_t offset, size_t size, int index, Result* outResult = nullptr);
   void setUniform(const UniformDesc& uniformDesc, const void* data, Result* outResult = nullptr);
 
   void setPipelineState(const std::shared_ptr<IComputePipelineState>& newValue);

--- a/src/igl/opengl/RenderCommandAdapter.cpp
+++ b/src/igl/opengl/RenderCommandAdapter.cpp
@@ -141,9 +141,10 @@ void RenderCommandAdapter::setUniform(const UniformDesc& uniformDesc,
 
 void RenderCommandAdapter::setUniformBuffer(Buffer* buffer,
                                             size_t offset,
+                                            size_t size,
                                             uint32_t index,
                                             Result* outResult) {
-  uniformAdapter_.setUniformBuffer(buffer, offset, index, outResult);
+  uniformAdapter_.setUniformBuffer(buffer, offset, size, index, outResult);
 }
 
 void RenderCommandAdapter::clearVertexTexture() {

--- a/src/igl/opengl/RenderCommandAdapter.h
+++ b/src/igl/opengl/RenderCommandAdapter.h
@@ -64,7 +64,7 @@ class RenderCommandAdapter final : public WithContext {
   void setIndexBuffer(Buffer& buffer);
 
   void clearUniformBuffers();
-  void setUniformBuffer(Buffer* buffer, size_t offset, uint32_t index, Result* outResult = nullptr);
+  void setUniformBuffer(Buffer* buffer, size_t offset, size_t size, uint32_t index, Result* outResult = nullptr);
   void setUniform(const UniformDesc& uniformDesc, const void* data, Result* outResult = nullptr);
 
   void clearVertexTexture();

--- a/src/igl/opengl/RenderCommandEncoder.cpp
+++ b/src/igl/opengl/RenderCommandEncoder.cpp
@@ -261,8 +261,6 @@ void RenderCommandEncoder::bindBuffer(uint32_t index,
                                       IBuffer* buffer,
                                       size_t offset,
                                       size_t bufferSize) {
-  (void)bufferSize;
-
   if (IGL_DEBUG_VERIFY(adapter_) && buffer) {
     auto* glBuffer = static_cast<Buffer*>(buffer);
     auto bufferType = glBuffer->getType();
@@ -270,7 +268,7 @@ void RenderCommandEncoder::bindBuffer(uint32_t index,
     if (bufferType == Buffer::Type::Uniform) {
       IGL_DEBUG_ASSERT_NOT_IMPLEMENTED();
     } else if (bufferType == Buffer::Type::UniformBlock) {
-      adapter_->setUniformBuffer(glBuffer, offset, index);
+      adapter_->setUniformBuffer(glBuffer, offset, bufferSize, index);
     }
   }
 }

--- a/src/igl/opengl/UniformAdapter.cpp
+++ b/src/igl/opengl/UniformAdapter.cpp
@@ -175,12 +175,10 @@ void UniformAdapter::bindToPipeline(IContext& context) {
   for (size_t bindingIndex = 0; bindingIndex < IGL_UNIFORM_BLOCKS_BINDING_MAX; ++bindingIndex) {
     if (uniformBuffersDirtyMask_ & (1 << bindingIndex)) {
       auto uniformBinding = uniformBufferBindingMap_.at(bindingIndex);
-      auto* bufferState = static_cast<UniformBlockBuffer*>(std::get<0>(uniformBinding));
-      auto offset = std::get<1>(uniformBinding);
-      auto size = std::get<2>(uniformBinding);
+      auto* bufferState = static_cast<UniformBlockBuffer*>(uniformBinding.buffer);
       IGL_DEBUG_ASSERT(bufferState);
-      if (offset) {
-        bufferState->bindRange(bindingIndex, offset, size, nullptr);
+      if (uniformBinding.offset) {
+        bufferState->bindRange(bindingIndex, uniformBinding.offset, uniformBinding.size, nullptr);
       } else {
         bufferState->bindBase(bindingIndex, nullptr);
       }

--- a/src/igl/opengl/UniformAdapter.cpp
+++ b/src/igl/opengl/UniformAdapter.cpp
@@ -128,6 +128,7 @@ void UniformAdapter::setUniform(const UniformDesc& uniformDesc,
 
 void UniformAdapter::setUniformBuffer(IBuffer* buffer,
                                       size_t offset,
+                                      size_t size,
                                       uint32_t bindingIndex,
                                       Result* outResult) {
   IGL_DEBUG_ASSERT(bindingIndex <= IGL_UNIFORM_BLOCKS_BINDING_MAX,
@@ -136,7 +137,7 @@ void UniformAdapter::setUniformBuffer(IBuffer* buffer,
                    IGL_UNIFORM_BLOCKS_BINDING_MAX);
   IGL_DEBUG_ASSERT(buffer, "invalid buffer passed to setUniformBuffer");
   if (bindingIndex < IGL_UNIFORM_BLOCKS_BINDING_MAX && buffer) {
-    uniformBufferBindingMap_[bindingIndex] = {buffer, offset};
+    uniformBufferBindingMap_[bindingIndex] = {buffer, offset, size};
     uniformBuffersDirtyMask_ |= 1 << bindingIndex;
     Result::setOk(outResult);
   } else {
@@ -174,10 +175,12 @@ void UniformAdapter::bindToPipeline(IContext& context) {
   for (size_t bindingIndex = 0; bindingIndex < IGL_UNIFORM_BLOCKS_BINDING_MAX; ++bindingIndex) {
     if (uniformBuffersDirtyMask_ & (1 << bindingIndex)) {
       auto uniformBinding = uniformBufferBindingMap_.at(bindingIndex);
-      auto* bufferState = static_cast<UniformBlockBuffer*>(uniformBinding.first);
+      auto* bufferState = static_cast<UniformBlockBuffer*>(std::get<0>(uniformBinding));
+      auto offset = std::get<1>(uniformBinding);
+      auto size = std::get<2>(uniformBinding);
       IGL_DEBUG_ASSERT(bufferState);
-      if (uniformBinding.second) {
-        bufferState->bindRange(bindingIndex, uniformBinding.second, nullptr);
+      if (offset) {
+        bufferState->bindRange(bindingIndex, offset, size, nullptr);
       } else {
         bufferState->bindBase(bindingIndex, nullptr);
       }

--- a/src/igl/opengl/UniformAdapter.h
+++ b/src/igl/opengl/UniformAdapter.h
@@ -29,7 +29,7 @@ class UniformAdapter {
   void shrinkUniformUsage();
   void clearUniformBuffers();
   void setUniform(const UniformDesc& uniformDesc, const void* data, Result* outResult);
-  void setUniformBuffer(IBuffer* buffer, size_t offset, uint32_t index, Result* outResult);
+  void setUniformBuffer(IBuffer* buffer, size_t offset, size_t size, uint32_t index, Result* outResult);
 
   [[nodiscard]] uint32_t getMaxUniforms() const {
     return maxUniforms_;
@@ -51,7 +51,7 @@ class UniformAdapter {
   uint32_t maxUniforms_ = 1024;
 
   // map for uniform binding indices to the buffers
-  std::unordered_map<int, std::pair<IBuffer*, size_t>> uniformBufferBindingMap_;
+  std::unordered_map<int, std::tuple<IBuffer*, size_t, size_t>> uniformBufferBindingMap_;
   uint32_t uniformBuffersDirtyMask_ = 0;
   static_assert(sizeof(uniformBuffersDirtyMask_) * 8 >= IGL_UNIFORM_BLOCKS_BINDING_MAX,
                 "uniformBuffersDirtyMask size is not enough to fit the flags");

--- a/src/igl/opengl/UniformAdapter.h
+++ b/src/igl/opengl/UniformAdapter.h
@@ -49,9 +49,15 @@ class UniformAdapter {
   std::vector<UniformState> uniforms_;
   std::vector<uint8_t> uniformData_;
   uint32_t maxUniforms_ = 1024;
+    
+  struct UniformBufferRange{
+    IBuffer* buffer;
+    size_t offset;
+    size_t size;
+  };
 
   // map for uniform binding indices to the buffers
-  std::unordered_map<int, std::tuple<IBuffer*, size_t, size_t>> uniformBufferBindingMap_;
+  std::unordered_map<int, UniformBufferRange> uniformBufferBindingMap_;
   uint32_t uniformBuffersDirtyMask_ = 0;
   static_assert(sizeof(uniformBuffersDirtyMask_) * 8 >= IGL_UNIFORM_BLOCKS_BINDING_MAX,
                 "uniformBuffersDirtyMask size is not enough to fit the flags");


### PR DESCRIPTION
glBindBufferRange() use the precise size when bufferSize > 0, and use remaining size starting from `bufferOffset` when bufferSize = 0.