### PR TITLE
igl | OpenGL | Support glPolygonOffsetClamp() by GL_ARB_polygon_offset_clamp extension.

### DIFF
--- a/src/igl/opengl/DeviceFeatureSet.cpp
+++ b/src/igl/opengl/DeviceFeatureSet.cpp
@@ -251,7 +251,7 @@ bool DeviceFeatureSet::isExtensionSupported(Extensions extension) const {
   case Extensions::VertexAttribDivisor:
     return hasESExtension(*this, "GL_NV_instanced_arrays");
   case Extensions::PolygonOffsetClamp:
-    return hasESExtension(*this, "GL_ARB_polygon_offset_clamp");
+    return hasDesktopOrESExtension(*this, "GL_ARB_polygon_offset_clamp");
   }
   IGL_UNREACHABLE_RETURN(false)
 }

--- a/src/igl/opengl/DeviceFeatureSet.cpp
+++ b/src/igl/opengl/DeviceFeatureSet.cpp
@@ -250,6 +250,8 @@ bool DeviceFeatureSet::isExtensionSupported(Extensions extension) const {
     return hasESExtension(*this, "GL_OES_vertex_array_object");
   case Extensions::VertexAttribDivisor:
     return hasESExtension(*this, "GL_NV_instanced_arrays");
+  case Extensions::PolygonOffsetClamp:
+    return hasESExtension(*this, "GL_ARB_polygon_offset_clamp");
   }
   IGL_UNREACHABLE_RETURN(false)
 }

--- a/src/igl/opengl/DeviceFeatureSet.h
+++ b/src/igl/opengl/DeviceFeatureSet.h
@@ -58,6 +58,7 @@ enum class Extensions {
   TextureType2_10_10_10_Rev,  // GL_EXT_texture_type_2_10_10_10_REV is supporteds
   VertexArrayObject,          // GL_OES_vertex_array_object is supported
   VertexAttribDivisor,        // GL_NV_instanced_arrays is supported
+  PolygonOffsetClamp,         // GL_ARB_polygon_offset_clamp is supported
 };
 // clang-format on
 

--- a/src/igl/opengl/GLFunc.cpp
+++ b/src/igl/opengl/GLFunc.cpp
@@ -1190,12 +1190,12 @@ void iglGenVertexArrays(GLsizei n, GLuint* vertexArrays) {
 #endif
 
 void iglPolygonOffsetClamp(float factor, float units, float clamp){
-  GLEXTENSION_METHOD_BODY_WITH_RETURN(CAN_CALL_glPolygonOffsetClamp,
-                                      glPolygonOffsetClamp,
-                                      PFNPOLYGONOFFSETCLAMPPROC,
-                                      factor,
-                                      units,
-                                      clamp);
+  GLEXTENSION_METHOD_BODY(CAN_CALL_glPolygonOffsetClamp,
+                          glPolygonOffsetClamp,
+                          PFNPOLYGONOFFSETCLAMPPROC,
+                          factor,
+                          units,
+                          clamp);
 }
 
 ///--------------------------------------

--- a/src/igl/opengl/GLFunc.cpp
+++ b/src/igl/opengl/GLFunc.cpp
@@ -1181,6 +1181,24 @@ void iglGenVertexArrays(GLsizei n, GLuint* vertexArrays) {
 }
 
 ///--------------------------------------
+/// MARK: - GL_ARB_polygon_offset_clamp
+
+#if defined(GL_ARB_polygon_offset_clamp)
+#define CAN_CALL_glPolygonOffsetClamp CAN_CALL
+#else
+#define CAN_CALL_glPolygonOffsetClamp 0
+#endif
+
+void iglPolygonOffsetClamp(float factor, float units, float clamp){
+  GLEXTENSION_METHOD_BODY_WITH_RETURN(CAN_CALL_glPolygonOffsetClamp,
+                                      glPolygonOffsetClamp,
+                                      PFNPOLYGONOFFSETCLAMPPROC,
+                                      factor,
+                                      units,
+                                      clamp);
+}
+
+///--------------------------------------
 /// MARK: - GL_EXT_debug_label
 
 #if defined(GL_EXT_debug_label)

--- a/src/igl/opengl/GLFunc.h
+++ b/src/igl/opengl/GLFunc.h
@@ -289,6 +289,8 @@ using PFNIGLDRAWARRAYSINSTANCEDPROC = void (*)(GLenum mode,
                                                GLsizei count,
                                                GLsizei primcount);
 
+using PFNPOLYGONOFFSETCLAMPPROC = void (*)(float factor, float units, float clamp);
+
 ///--------------------------------------
 /// MARK: - OpenGL ES / OpenGL
 
@@ -547,6 +549,12 @@ void iglUniformBlockBinding(GLuint pid, GLuint uniformBlockIndex, GLuint uniform
 void iglBindVertexArray(GLuint vao);
 void iglDeleteVertexArrays(GLsizei n, const GLuint* vertexArrays);
 void iglGenVertexArrays(GLsizei n, GLuint* vertexArrays);
+
+///--------------------------------------
+/// MARK: - GL_ARB_polygon_offset_clamp
+
+void iglPolygonOffsetClamp(float factor, float units, float clamp);
+
 
 ///--------------------------------------
 /// MARK: - GL_EXT_debug_label

--- a/src/igl/opengl/IContext.cpp
+++ b/src/igl/opengl/IContext.cpp
@@ -2272,9 +2272,14 @@ void IContext::pixelStorei(GLenum pname, GLint param) {
   GLCHECK_ERRORS();
 }
 
-void IContext::polygonOffset(GLfloat factor, GLfloat units) {
-  GLCALL(PolygonOffset)(factor, units);
-  APILOG("glPolygonOffset(%f, %f)\n", factor, units);
+void IContext::polygonOffsetClamp(GLfloat factor, GLfloat units, float clamp){
+  if (deviceFeatureSet_.hasExtension(Extensions::PolygonOffsetClamp)){
+    iglPolygonOffsetClamp(factor, units, clamp);
+    APILOG("glPolygonOffsetClamp(%f, %f, %f)\n", factor, units, clamp);
+  } else {
+    GLCALL(PolygonOffset)(factor, units);
+    APILOG("glPolygonOffset(%f, %f)\n", factor, units);
+  }
   GLCHECK_ERRORS();
 }
 

--- a/src/igl/opengl/IContext.h
+++ b/src/igl/opengl/IContext.h
@@ -291,7 +291,7 @@ class IContext {
   void* mapBufferRange(GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
   void objectLabel(GLenum identifier, GLuint name, GLsizei length, const char* label);
   void pixelStorei(GLenum pname, GLint param);
-  void polygonOffset(GLfloat factor, GLfloat units);
+  void polygonOffsetClamp(GLfloat factor, GLfloat units, float clamp);
   void popDebugGroup();
   void pushDebugGroup(GLenum source, GLuint id, GLsizei length, const GLchar* message);
   void readPixels(GLint x,

--- a/src/igl/opengl/RenderCommandAdapter.cpp
+++ b/src/igl/opengl/RenderCommandAdapter.cpp
@@ -97,9 +97,9 @@ void RenderCommandAdapter::setBlendColor(Color color) {
   getContext().blendColor(color.r, color.g, color.b, color.a);
 }
 
-void RenderCommandAdapter::setDepthBias(float depthBias, float slopeScale) {
+void RenderCommandAdapter::setDepthBias(float depthBias, float slopeScale, float clamp) {
   getContext().setEnabled(true, GL_POLYGON_OFFSET_FILL);
-  getContext().polygonOffset(slopeScale, depthBias);
+  getContext().polygonOffsetClamp(slopeScale, depthBias, clamp);
 }
 
 void RenderCommandAdapter::clearVertexBuffers() {

--- a/src/igl/opengl/RenderCommandAdapter.h
+++ b/src/igl/opengl/RenderCommandAdapter.h
@@ -57,7 +57,7 @@ class RenderCommandAdapter final : public WithContext {
   void setDepthStencilState(const std::shared_ptr<IDepthStencilState>& newValue);
   void setStencilReferenceValue(uint32_t value);
   void setBlendColor(Color color);
-  void setDepthBias(float depthBias, float slopeScale);
+  void setDepthBias(float depthBias, float slopeScale, float clamp);
 
   void clearVertexBuffers();
   void setVertexBuffer(Buffer& buffer, size_t offset, size_t index, Result* outResult = nullptr);

--- a/src/igl/opengl/RenderCommandEncoder.cpp
+++ b/src/igl/opengl/RenderCommandEncoder.cpp
@@ -122,7 +122,7 @@ void RenderCommandEncoder::endEncoding() {
 
     // Disable depthBias
     getContext().setEnabled(false, GL_POLYGON_OFFSET_FILL);
-    adapter_->setDepthBias(0.0f, 0.0f);
+    adapter_->setDepthBias(0.0f, 0.0f, 0.0f);
 
     adapter_->endEncoding();
     getContext().getAdapterPool().push_back(std::move(adapter_));
@@ -427,9 +427,9 @@ void RenderCommandEncoder::setBlendColor(Color color) {
   }
 }
 
-void RenderCommandEncoder::setDepthBias(float depthBias, float slopeScale, float /*clamp*/) {
+void RenderCommandEncoder::setDepthBias(float depthBias, float slopeScale, float clamp) {
   if (IGL_DEBUG_VERIFY(adapter_)) {
-    adapter_->setDepthBias(depthBias, slopeScale);
+    adapter_->setDepthBias(depthBias, slopeScale, clamp);
   }
 }
 


### PR DESCRIPTION
Unfortunately, I don't have a suitable device at the moment to test this feature.