### PR TITLE
igl | shell | Fix screen rotate failed on android vulkan.

### DIFF
--- a/shell/android/jni/TinyRenderer.cpp
+++ b/shell/android/jni/TinyRenderer.cpp
@@ -239,6 +239,7 @@ void TinyRenderer::onSurfacesChanged(ANativeWindow* /*surface*/, int width, int 
 #if IGL_BACKEND_VULKAN
   if (backendVersion_.flavor == igl::BackendFlavor::Vulkan) {
     recreateSwapchain(nativeWindow_, false);
+    platform_->updatePreRotationMatrix();
   }
 #endif
 }

--- a/shell/shared/platform/android/PlatformAndroid.cpp
+++ b/shell/shared/platform/android/PlatformAndroid.cpp
@@ -78,7 +78,9 @@ PlatformAndroid::PlatformAndroid(std::shared_ptr<igl::IDevice> device, bool useF
         // @fb-only
     imageWriter_ = std::make_unique<igl::shell::ImageWriterAndroid>();
   }
+}
 
+void PlatformAndroid::updatePreRotationMatrix() {
 #if IGL_BACKEND_VULKAN
   if (device_->getBackendType() != igl::BackendType::Vulkan)
     return;

--- a/shell/shared/platform/android/PlatformAndroid.h
+++ b/shell/shared/platform/android/PlatformAndroid.h
@@ -22,6 +22,7 @@ class PlatformAndroid : public Platform {
   ImageLoader& getImageLoader() noexcept override;
   [[nodiscard]] const ImageWriter& getImageWriter() const noexcept override;
   [[nodiscard]] FileLoader& getFileLoader() const noexcept override;
+  void updatePreRotationMatrix();
 
  private:
   std::shared_ptr<igl::IDevice> device_;


### PR DESCRIPTION
Fix the issue of failed screen rotation in Android Vulkan by updating the matrix in real-time.