### PR TITLE
igl | shell | The default OpenGLView. contentsScale is 1.0, use the screen scale instead.

### DIFF
--- a/shell/ios/ViewController.mm
+++ b/shell/ios/ViewController.mm
@@ -207,6 +207,7 @@
                                                    kEAGLDrawablePropertyColorFormat,
                                                    nil];
     self.view = openGLView;
+    self.view.layer.contentsScale = [UIScreen mainScreen].scale;
 #endif
     break;
   }


### PR DESCRIPTION
Fixing the issue of image resolution.
| Before | New |
|--------|--------|
|![image](https://github.com/user-attachments/assets/bd97b0b4-b243-40c3-924b-d28940b507a0) | ![image](https://github.com/user-attachments/assets/065dc5ff-a3fe-4c91-bb12-c1583dbbfacb) |