### PR TITLE
igl | shell | ImageLoader : make fileLoader() function become public.

### DIFF
--- a/shell/shared/imageLoader/ImageLoader.h
+++ b/shell/shared/imageLoader/ImageLoader.h
@@ -43,7 +43,6 @@ class ImageLoader {
       uint32_t length,
       std::optional<igl::TextureFormat> preferredFormat = {}) noexcept;
 
- protected:
   [[nodiscard]] const FileLoader& fileLoader() const noexcept {
     return fileLoader_;
   }


### PR DESCRIPTION
This is a prerequisite PR for igl nanovg(https://github.com/facebook/igl/pull/213).