### PR TITLE
igl | third-party | Fix patch : nanovg.py

### DIFF
--- a/third-party/deps/patches/nanovg.py
+++ b/third-party/deps/patches/nanovg.py
@@ -9,13 +9,14 @@ lib_dir=os.path.join(base_dir, "src", "nanovg")
 
 file = Path(os.path.join(lib_dir, "example/demo.c"))
 file.write_text(file.read_text()
-  .replace("#include <GLFW/glfw3.h>", "")
+  .replace("#include <GLFW/glfw3.h>", "#include <stdlib.h>")
   .replace("#define STB_IMAGE_WRITE_IMPLEMENTATION", "")
   .replace("glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, image);", "// glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, image);")
 )
 
 file = Path(os.path.join(lib_dir, "example/perf.c"))
 file.write_text(file.read_text()
+  .replace("#include <GLFW/glfw3.h>", "")
   .replace("void startGPUTimer(GPUtimer* timer)",
 ("""#if 0
 void startGPUTimer(GPUtimer* timer)


### PR DESCRIPTION
Fix two compile error : 
<img width="1865" alt="企业微信截图_f2a280e9-0cff-45fe-b7f8-79647a9050d8" src="https://github.com/user-attachments/assets/55f3a96c-9e41-456d-838f-9dd30ea2c31a" />

<img width="910" alt="企业微信截图_6689e763-15a3-42ce-87f3-56dd16b115b0" src="https://github.com/user-attachments/assets/a8fc069b-d19f-43a3-a4f1-1b983320f05d" />
