### PR TITLE
igl | cmake | Sanitize compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,13 @@ if(NOT APPLE)
   set(IGL_WITH_METAL OFF)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # disable for all targets due to warnings in third-party code
+  add_definitions(-Wno-nullability-completeness)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-volatile>)
+endif()
+
 if(ANDROID)
   if(IGL_WITH_OPENGL)
     set(IGL_WITH_OPENGLES ON)
@@ -54,12 +61,9 @@ if(ANDROID)
   set(IGL_WITH_OPENGL OFF)
   set(IGL_WITH_VULKAN ON)
   set(IGL_WITH_WEBGL OFF)
-  # disable for all targets due to warnings in third-party code
-  add_definitions(-Wno-nullability-completeness)
-  add_definitions(-Wno-deprecated-volatile)
 elseif(UNIX)
   # disable for all targets due to warnings in third-party code
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-volatile>)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-volatile>)
   add_definitions(-Wno-attributes)
 endif()
 

--- a/IGLU/CMakeLists.txt
+++ b/IGLU/CMakeLists.txt
@@ -61,7 +61,7 @@ target_include_directories(IGLUtexture_accessor PUBLIC "${IGL_ROOT_DIR}/third-pa
 
 if(UNIX)
   if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(IGLUimgui PUBLIC "-Wno-volatile")
+    target_compile_options(IGLUimgui PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wno-volatile>)
   endif()
 endif()
 

--- a/src/igl/glslang/CMakeLists.txt
+++ b/src/igl/glslang/CMakeLists.txt
@@ -39,4 +39,5 @@ target_link_libraries(IGLGlslang PUBLIC glslang SPIRV glslang-default-resource-l
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(IGLGlslang PRIVATE "-Wno-nullability-completeness")
+  target_compile_options(MachineIndependent PRIVATE "-Wno-unused-but-set-variable")
 endif()

--- a/src/igl/tests/CMakeLists.txt
+++ b/src/igl/tests/CMakeLists.txt
@@ -114,6 +114,6 @@ endif()
 
 if(UNIX)
   if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(IGLTests PUBLIC "-Wno-volatile")
+    target_compile_options(IGLTests PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wno-volatile>)
   endif()
 endif()


### PR DESCRIPTION
Fixed Clang/GCC compilation warnings.