### PR TITLE
igl | vulkan | Fix VulkanContext::initContext() passed in requestedFe…

### DIFF
--- a/src/igl/vulkan/VulkanContext.cpp
+++ b/src/igl/vulkan/VulkanContext.cpp
@@ -787,9 +787,10 @@ igl::Result VulkanContext::initContext(const HWDeviceDesc& desc,
   // Use the requested features passed to the function (if any) or use the default features
   if (requestedFeatures) {
     features_ = *requestedFeatures;
-  } else {
-    features_.populateWithAvailablePhysicalDeviceFeatures(*this, vkPhysicalDevice_);
   }
+
+  features_.populateWithAvailablePhysicalDeviceFeatures(*this, vkPhysicalDevice_);
+
   // ... and check whether they are available in the physical device (they should be)
   {
     auto featureCheckResult = features_.checkSelectedFeatures(availableFeatures);


### PR DESCRIPTION
…atures, since VulkanFeatures::extensionProps_ is empty, the assembleFeatureChain() for the extensions does not actually succeed.

FOR:https://github.com/facebook/igl/issues/272

