### PR TITLE
Fix cmake error when setting IGL_DEPLOY_DEPS

### DIFF
--- a/src/igl/CMakeLists.txt
+++ b/src/igl/CMakeLists.txt
@@ -41,7 +41,9 @@ endif()
 igl_set_cxxstd(IGLLibrary 20)
 igl_set_folder(IGLLibrary "IGL")
 
-add_subdirectory(glslang)
+if(IGL_DEPLOY_DEPS)
+  add_subdirectory(glslang)
+endif()
 
 if(IGL_WITH_OPENGL OR IGL_WITH_OPENGLES OR IGL_WITH_WEBGL)
   add_subdirectory(opengl)


### PR DESCRIPTION
Setting IGL_DEPLOY_DEPS resulted in a cmake error because glslang was used regardless of that option. Here, I'm simply making it respect that option, which fixes the error in some cases.

From what I can tell, glslang is only used by the vulkan backend and IGLU shaderCross. On the interaction between IGL_DEPLOY_DEPS and those libraries:
- Using IGLU without deps is not realistic (too many dependencies), so they simply have to go together.
- However, the vulkan uses glslang directly and therefore can't be built when setting IGL_DEPLOY_DEPS. I think that should be an optional dependency instead, but I'm not addressing that issue.
