### PR TITLE
igl | opengl | Fix glDrawBuffers() will fail if the set color_attachment_N indices are not consecutive.

### DIFF
--- a/src/igl/opengl/Framebuffer.cpp
+++ b/src/igl/opengl/Framebuffer.cpp
@@ -587,10 +587,10 @@ void CustomFramebuffer::prepareResource(const std::string& debugName, Result* ou
     if (colorAttachment.texture != nullptr) {
       attachAsColor(*colorAttachment.texture, static_cast<uint32_t>(i), attachmentParams);
       drawBuffers.push_back(static_cast<GLenum>(GL_COLOR_ATTACHMENT0 + i));
+    } else {
+      drawBuffers.push_back(GL_NONE);
     }
   }
-
-  std::sort(drawBuffers.begin(), drawBuffers.end());
 
   if (drawBuffers.size() > 1) {
     getContext().drawBuffers(static_cast<GLsizei>(drawBuffers.size()), drawBuffers.data());


### PR DESCRIPTION
https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glDrawBuffers.xhtml

GL_INVALID_OPERATION is generated if the GL is bound to a framebuffer object and the ith buffer listed in bufs is anything other than GL_NONE or GL_COLOR_ATTACHMENTSi.