### PR TITLE
igl | opengl | compute | Fix compute encoder set wrong binding point at binding buffer.

### DIFF
--- a/src/igl/opengl/ComputePipelineState.cpp
+++ b/src/igl/opengl/ComputePipelineState.cpp
@@ -137,7 +137,7 @@ Result ComputePipelineState::bindBuffer(const size_t unit, Buffer* buffer) {
   }
 
   Result result;
-  static_cast<ArrayBuffer&>(*buffer).bindBase(bufferLocation, &result);
+  static_cast<ArrayBuffer&>(*buffer).bindBase(unit, &result);
 
   return result;
 }


### PR DESCRIPTION
glBindBufferBase(GL_SHADER_STORAGE_BUFFER, binding_point, ssbo_buffer_id);

The second parameter should be the binding point, not the SSBO index.

If my API usage is correct, my code is as follows: : 
```c++
#version 460
struct Particle{
}

layout(std140, set = 1, binding = 7) readonly buffer buffer_1{
    Particle particlesIn[];
};
layout(std140, set = 1, binding = 8) buffer buffer_2{
    Particle particlesOut[];
};

layout (local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
void main(){

}
``` 

```c++
igl::ComputePipelineDesc desc;
desc.buffersMap[7] = IGL_NAMEHANDLE("buffer_1");
desc.buffersMap[8] = IGL_NAMEHANDLE("buffer_2");
compute_pipeline_state_ = device->createComputePipelineState(desc);
``` 

```c++
compute_encoder->bindBuffer(7, buffer_1);
compute_encoder->bindBuffer(8, buffer_2);
``` 