### PR TITLE
igl | opengl | Fix android hardware buffer upload texture failed if bytesPerRow == 0.

### DIFF
--- a/src/igl/opengl/egl/android/NativeHWBuffer.cpp
+++ b/src/igl/opengl/egl/android/NativeHWBuffer.cpp
@@ -172,6 +172,7 @@ Result NativeHWTextureBuffer::uploadInternal(TextureType /*type*/,
   auto lockGuard
       [[maybe_unused]] = lockHWBuffer(reinterpret_cast<std::byte**>(&dst), outRange, &outResult);
   auto internalBpr = getProperties().getBytesPerRow(outRange.stride);
+  bytesPerRow = bytesPerRow > 0 ? bytesPerRow : getProperties().getBytesPerRow(range);
 
   if (outResult.isOk() && dst != nullptr && bytesPerRow <= internalBpr &&
       range.width == outRange.width && range.height == outRange.height) {


### PR DESCRIPTION
Fix for issue : https://github.com/facebook/igl/issues/248