### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Get output time
       run: echo "The time was ${{ steps.build.outputs.time }}"
     - name: Deploy
-      uses: JamesIves/github-pages-deploy-action@releases/v4
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         BRANCH: gh-pages # The branch the action should deploy to
         FOLDER: ./docs/build/html # The folder the action should deploy


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `JamesIves/github-pages-deploy-action` | [`releases/v4`](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/releases/v4) | [`v4`](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4) | [Release](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4) | doc-build.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
