### PR TITLE
 properly bind fragment uniform buffer in multi-pass rendering

### DIFF
--- a/shell/renderSessions/TQMultiRenderPassSession.cpp
+++ b/shell/renderSessions/TQMultiRenderPassSession.cpp
@@ -208,8 +208,6 @@ static void render(std::shared_ptr<ICommandBuffer>& buffer,
     if (fragmentParamBuffer) {
         commands->bindBuffer(0, fragmentParamBuffer.get());
     }
-}
-
   } else {
     // Bind non block uniforms
     for (const auto& uniformDesc : fragmentUniformDescriptors) {


### PR DESCRIPTION
Fix syntax error in uniform buffer binding

Fixed misplaced brace that prevented uniform buffers from being bound
for Metal/D3D12 backends in multi-pass rendering.

**Root Cause:** The original code had incorrect brace placement:
```cpp
if (backend != igl::BackendType::OpenGL) {
  if (fragmentParamBuffer) {
      commands->bindBuffer(0, fragmentParamBuffer.get());
  }
}  // <-- Ends here incorrectly

} else {  // <-- Syntax error: disconnected else