### PR TITLE
igl | vulkan | Use AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER to match VK_IMAGE_USAGE_STORAGE_BIT.

### DIFF
--- a/src/igl/vulkan/android/NativeHWBuffer.cpp
+++ b/src/igl/vulkan/android/NativeHWBuffer.cpp
@@ -67,9 +67,8 @@ Result NativeHWTextureBuffer::createTextureInternal(AHardwareBuffer* hwBuffer) {
   }
   if (hwbDesc.usage & AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT) {
     usage_flags |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    // There is no matching usage flag in AHardwareBuffer to match VK_IMAGE_USAGE_STORAGE_BIT in
-    // Vulkan. So we assume if the the color output flag is set for the buffer, we
-    // enable the storage usage.
+  }
+  if (hwbDesc.usage & AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER) {
     usage_flags |= VK_IMAGE_USAGE_STORAGE_BIT;
   }
 


### PR DESCRIPTION
https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#memory-external-android-hardware-buffer-usage