### PR TITLE
igl | metal | Even if you do not dynamically modify the constants within a shader, you are still required to create the MTLFunction via API 'newFunctionWithName:constantValues:' if it contains constant variables.

### DIFF
--- a/src/igl/metal/Device.mm
+++ b/src/igl/metal/Device.mm
@@ -798,12 +798,8 @@ std::unique_ptr<IShaderLibrary> Device::createShaderLibrary(const ShaderLibraryD
     }
 
     const auto& constantValues = info.functionConstantValues.getConstantValues();
-    id<MTLFunction> metalFunction = nil;
-    if (constantValues.empty()) {
-      // Fast path: no specialization constants — skip MTLFunctionConstantValues allocation.
-      metalFunction = [metalLibrary newFunctionWithName:shaderEntrypoint];
-    } else {
-      MTLFunctionConstantValues* metalConstantValues = [MTLFunctionConstantValues new];
+    MTLFunctionConstantValues* metalConstantValues = [MTLFunctionConstantValues new];
+    if (!constantValues.empty()) {
       const uint8_t* constantsBase = info.functionConstantValues.getData().data();
       for (size_t i = 0; i < constantValues.size(); ++i) {
         const auto& entry = constantValues[i];
@@ -814,10 +810,10 @@ std::unique_ptr<IShaderLibrary> Device::createShaderLibrary(const ShaderLibraryD
                                          type:convertConstantValueType(entry.type)
                                       atIndex:i];
       }
-      metalFunction = [metalLibrary newFunctionWithName:shaderEntrypoint
-                                         constantValues:metalConstantValues
-                                                  error:&error];
     }
+    id<MTLFunction> metalFunction = [metalLibrary newFunctionWithName:shaderEntrypoint
+                                                       constantValues:metalConstantValues
+                                                                error:&error];
     if (!metalFunction) {
       IGL_DEBUG_ABORT("Could not find function '%s' in library\n", info.entryPoint.c_str());
       Result::setResult(


### PR DESCRIPTION
error 'Render Pipeline Descriptor Validation
fragmentFunction main0 cannot be used to build a pipeline state. Use newFunctionWithName:constantValues:... to get the specialized function
'