### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -10,6 +10,9 @@ on:
 env:
   GIT_CLONE_PROTECTION_ACTIVE: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Android (Ubuntu)"

--- a/.github/workflows/cmake-install-test.yml
+++ b/.github/workflows/cmake-install-test.yml
@@ -22,6 +22,9 @@ on:
 env:
   GIT_CLONE_PROTECTION_ACTIVE: false
 
+permissions:
+  contents: read
+
 jobs:
   install-test:
     strategy:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
   build_docs_job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.