### PR TITLE
igl | Add Alpha-to-Coverage support across all backends

### DIFF
--- a/src/igl/RenderPipelineState.cpp
+++ b/src/igl/RenderPipelineState.cpp
@@ -52,6 +52,10 @@ bool RenderPipelineDesc::operator==(const RenderPipelineDesc& other) const {
     return false;
   }
 
+  if (alphaToCoverageEnabled != other.alphaToCoverageEnabled) {
+    return false;
+  }
+
   for (size_t i = 0; i != IGL_TEXTURE_SAMPLERS_MAX; i++) {
     if (immutableSamplers[i] != other.immutableSamplers[i]) {
       return false;
@@ -77,6 +81,7 @@ size_t std::hash<RenderPipelineDesc>::operator()(const RenderPipelineDesc& key) 
   hash ^= std::hash<RenderPipelineDesc::TargetDesc>()(key.targetDesc);
   hash ^= std::hash<int>()(EnumToValue(key.cullMode));
   hash ^= std::hash<uint32_t>()(key.sampleCount);
+  hash ^= std::hash<bool>()(key.alphaToCoverageEnabled);
   hash ^= std::hash<int>()(EnumToValue(key.frontFaceWinding));
   hash ^= std::hash<int>()(EnumToValue(key.polygonFillMode));
   hash ^= std::hash<uint32_t>()(key.isDynamicBufferMask);

--- a/src/igl/RenderPipelineState.h
+++ b/src/igl/RenderPipelineState.h
@@ -202,6 +202,17 @@ struct RenderPipelineDesc {
 
   uint32_t sampleCount = 1u; // MSAA
 
+  /*
+   * @brief When enabled, the GPU computes a fragment's coverage from its alpha value,
+   * AND-ed with the geometric sample mask. This is a fixed-function alternative to
+   * shader-side `discard` for alpha-tested geometry. It does not break Early-Z because
+   * the decision happens in hardware after the fragment shader, not inside it.
+   *
+   * Requires `sampleCount > 1` (MSAA must be enabled) to take effect; otherwise the
+   * driver silently ignores it.
+   */
+  bool alphaToCoverageEnabled = false;
+
   // Vulkan only: specify if buffer binding locations correspond to Vulkan dynamic buffers
   uint32_t isDynamicBufferMask = 0; // one bit per each buffer binding slot
 

--- a/src/igl/d3d12/Device.cpp
+++ b/src/igl/d3d12/Device.cpp
@@ -1799,7 +1799,7 @@ std::shared_ptr<IRenderPipelineState> Device::createRenderPipeline(const RenderP
   psoDesc.RasterizerState.ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
 
   // Blend state - configure per render target based on pipeline descriptor
-  psoDesc.BlendState.AlphaToCoverageEnable = FALSE;
+  psoDesc.BlendState.AlphaToCoverageEnable = desc.alphaToCoverageEnabled ? TRUE : FALSE;
   const size_t numColorAttachments = desc.targetDesc.colorAttachments.size();
   psoDesc.BlendState.IndependentBlendEnable = numColorAttachments > 1 ? TRUE : FALSE;
 
@@ -2541,7 +2541,7 @@ igl::d3d12::ComPtr<ID3D12PipelineState> Device::createPipelineStateVariant(
   psoDesc.RasterizerState.ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
 
   // Blend state
-  psoDesc.BlendState.AlphaToCoverageEnable = FALSE;
+  psoDesc.BlendState.AlphaToCoverageEnable = desc.alphaToCoverageEnabled ? TRUE : FALSE;
   const size_t numColorAttachments = desc.targetDesc.colorAttachments.size();
   psoDesc.BlendState.IndependentBlendEnable = numColorAttachments > 1 ? TRUE : FALSE;
 

--- a/src/igl/metal/Device.mm
+++ b/src/igl/metal/Device.mm
@@ -522,6 +522,7 @@ std::shared_ptr<IRenderPipelineState> Device::createTraditionalRenderPipeline(
   metalDesc.label = [NSString stringWithUTF8String:desc.debugName.c_str()];
 
   metalDesc.sampleCount = desc.sampleCount;
+  metalDesc.alphaToCoverageEnabled = desc.alphaToCoverageEnabled ? YES : NO;
 
   // (optional, can be null) Vertex input
   auto vertexInput = desc.vertexInputState;
@@ -651,6 +652,7 @@ std::shared_ptr<IRenderPipelineState> Device::createMeshRenderPipeline(
     metalDesc.label = [NSString stringWithUTF8String:desc.debugName.c_str()];
 
     metalDesc.rasterSampleCount = desc.sampleCount;
+    metalDesc.alphaToCoverageEnabled = desc.alphaToCoverageEnabled ? YES : NO;
 
     if (!IGL_DEBUG_VERIFY(desc.shaderStages)) {
       Result::setResult(

--- a/src/igl/opengl/RenderPipelineState.cpp
+++ b/src/igl/opengl/RenderPipelineState.cpp
@@ -257,6 +257,13 @@ void RenderPipelineState::bind() {
     getContext().polygonFillMode((desc_.polygonFillMode == igl::PolygonFillMode::Fill) ? GL_FILL
                                                                                        : GL_LINE);
   }
+
+  // alpha-to-coverage (only meaningful when MSAA is active)
+  if (desc_.alphaToCoverageEnabled) {
+    getContext().enable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+  } else {
+    getContext().disable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+  }
 }
 
 void RenderPipelineState::unbind() {

--- a/src/igl/tests/Hash.cpp
+++ b/src/igl/tests/Hash.cpp
@@ -88,6 +88,13 @@ TEST_F(HashTest, GraphicsPipeline1) {
 
   ASSERT_NE(std::hash<RenderPipelineDesc>()(descOne), std::hash<RenderPipelineDesc>()(descTwo));
   descTwo.shaderStages = descOne.shaderStages;
+
+  // Modify alphaToCoverageEnabled
+  descTwo.alphaToCoverageEnabled = true;
+
+  ASSERT_NE(std::hash<RenderPipelineDesc>()(descOne), std::hash<RenderPipelineDesc>()(descTwo));
+  descTwo.alphaToCoverageEnabled = descOne.alphaToCoverageEnabled;
+  ASSERT_EQ(std::hash<RenderPipelineDesc>()(descOne), std::hash<RenderPipelineDesc>()(descTwo));
 }
 
 //
@@ -108,9 +115,9 @@ TEST_F(HashTest, GraphicsPipeline2) {
     return;
   }
 
-  // 64 is the size without unitSamplerMaps, colorAttachments, and debugName as those fields may
+  // 72 is the size without unitSamplerMaps, colorAttachments, and debugName as those fields may
   // vary between compilers and machines
-  const size_t expectedSize = 64 + 2 * sizeof(std::unordered_map<size_t, std::string>) +
+  const size_t expectedSize = 72 + 2 * sizeof(std::unordered_map<size_t, std::string>) +
                               sizeof(std::unordered_map<size_t, NameHandle>) +
                               sizeof(std::vector<RenderPipelineDesc::TargetDesc::ColorAttachment>) +
                               sizeof(NameHandle) +
@@ -158,6 +165,12 @@ TEST_F(HashTest, GraphicsPipeline3) {
   descTwo.shaderStages = shaderStages_;
   ASSERT_TRUE(descOne != descTwo);
   descTwo.shaderStages = descOne.shaderStages;
+  ASSERT_TRUE(descOne == descTwo);
+
+  // Change and restore alphaToCoverageEnabled
+  descTwo.alphaToCoverageEnabled = true;
+  ASSERT_TRUE(descOne != descTwo);
+  descTwo.alphaToCoverageEnabled = descOne.alphaToCoverageEnabled;
   ASSERT_TRUE(descOne == descTwo);
 }
 

--- a/src/igl/tests/metal/RenderPipelineCreation.mm
+++ b/src/igl/tests/metal/RenderPipelineCreation.mm
@@ -129,4 +129,55 @@ TEST_F(MetalRenderPipelineCreationTest, CreatePipelineWithDepthFormat) {
   ASSERT_NE(pipeline, nullptr);
 }
 
+//
+// CreatePipelineWithAlphaToCoverage
+//
+// Test creating a render pipeline with alpha-to-coverage enabled.
+// A2C is meaningful only when MSAA is active, so we set sampleCount = 4.
+//
+TEST_F(MetalRenderPipelineCreationTest, CreatePipelineWithAlphaToCoverage) {
+  Result res;
+
+  std::unique_ptr<IShaderStages> stages;
+  util::createSimpleShaderStages(device_, stages);
+  ASSERT_NE(stages, nullptr);
+
+  const RenderPipelineDesc pipelineDesc{
+      .shaderStages = std::move(stages),
+      .targetDesc = {.colorAttachments = {{.textureFormat = TextureFormat::RGBA_UNorm8}}},
+      .sampleCount = 4,
+      .alphaToCoverageEnabled = true,
+  };
+
+  auto pipeline = device_->createRenderPipeline(pipelineDesc, &res);
+  ASSERT_TRUE(res.isOk()) << res.message;
+  ASSERT_NE(pipeline, nullptr);
+}
+
+//
+// CreatePipelineAlphaToCoverageDefaultsOff
+//
+// Test that alpha-to-coverage is disabled by default and a pipeline created
+// without explicitly enabling it still creates successfully.
+//
+TEST_F(MetalRenderPipelineCreationTest, CreatePipelineAlphaToCoverageDefaultsOff) {
+  Result res;
+
+  std::unique_ptr<IShaderStages> stages;
+  util::createSimpleShaderStages(device_, stages);
+  ASSERT_NE(stages, nullptr);
+
+  const RenderPipelineDesc pipelineDesc{
+      .shaderStages = std::move(stages),
+      .targetDesc = {.colorAttachments = {{.textureFormat = TextureFormat::RGBA_UNorm8}}},
+  };
+
+  // The default value should be false; verify here so the default is locked down.
+  ASSERT_FALSE(pipelineDesc.alphaToCoverageEnabled);
+
+  auto pipeline = device_->createRenderPipeline(pipelineDesc, &res);
+  ASSERT_TRUE(res.isOk()) << res.message;
+  ASSERT_NE(pipeline, nullptr);
+}
+
 } // namespace igl::tests

--- a/src/igl/tests/ogl/RenderStateApplication.cpp
+++ b/src/igl/tests/ogl/RenderStateApplication.cpp
@@ -129,6 +129,33 @@ class RenderStateApplicationOGLTest : public ::testing::Test {
     cmdQueue_->submit(*cmdBuf);
   }
 
+  // Helper that creates and binds a pipeline with alpha-to-coverage configured.
+  void bindPipelineWithAlphaToCoverage(bool alphaToCoverageEnabled) {
+    const RenderPipelineDesc desc{
+        .vertexInputState = vertexInputState_,
+        .shaderStages = shaderStages_,
+        .targetDesc = {.colorAttachments = {{.textureFormat = offscreenTexture_->getFormat()}}},
+        .cullMode = CullMode::Disabled,
+        .alphaToCoverageEnabled = alphaToCoverageEnabled,
+    };
+
+    Result ret;
+    auto pipelineState = iglDev_->createRenderPipeline(desc, &ret);
+    ASSERT_TRUE(ret.isOk()) << ret.message.c_str();
+    ASSERT_NE(pipelineState, nullptr);
+
+    CommandBufferDesc cbDesc;
+    auto cmdBuf = cmdQueue_->createCommandBuffer(cbDesc, &ret);
+    ASSERT_EQ(ret.code, Result::Code::Ok);
+
+    auto cmdEncoder = cmdBuf->createRenderCommandEncoder(renderPass_, framebuffer_);
+    cmdEncoder->bindRenderPipelineState(pipelineState);
+    cmdEncoder->bindIndexBuffer(*ib_, IndexFormat::UInt16);
+    cmdEncoder->drawIndexed(0);
+    cmdEncoder->endEncoding();
+    cmdQueue_->submit(*cmdBuf);
+  }
+
  protected:
   std::shared_ptr<IDevice> iglDev_;
   std::shared_ptr<ICommandQueue> cmdQueue_;
@@ -225,6 +252,63 @@ TEST_F(RenderStateApplicationOGLTest, PolygonFillLine) {
   // but validate no GL errors occurred
   ASSERT_EQ(context_->checkForErrors(__FILE__, __LINE__), GL_NO_ERROR);
 #endif
+}
+
+//
+// AlphaToCoverageEnabled
+//
+// Verify that GL_SAMPLE_ALPHA_TO_COVERAGE is enabled after binding a pipeline
+// with alphaToCoverageEnabled = true.
+//
+TEST_F(RenderStateApplicationOGLTest, AlphaToCoverageEnabled) {
+  bindPipelineWithAlphaToCoverage(true);
+
+  GLboolean a2cEnabled = GL_FALSE;
+  context_->getBooleanv(GL_SAMPLE_ALPHA_TO_COVERAGE, &a2cEnabled);
+  ASSERT_EQ(a2cEnabled, GL_TRUE);
+  ASSERT_EQ(context_->checkForErrors(__FILE__, __LINE__), GL_NO_ERROR);
+}
+
+//
+// AlphaToCoverageDisabled
+//
+// Verify that GL_SAMPLE_ALPHA_TO_COVERAGE is disabled after binding a pipeline
+// with alphaToCoverageEnabled = false (the default).
+//
+TEST_F(RenderStateApplicationOGLTest, AlphaToCoverageDisabled) {
+  bindPipelineWithAlphaToCoverage(false);
+
+  GLboolean a2cEnabled = GL_TRUE;
+  context_->getBooleanv(GL_SAMPLE_ALPHA_TO_COVERAGE, &a2cEnabled);
+  ASSERT_EQ(a2cEnabled, GL_FALSE);
+  ASSERT_EQ(context_->checkForErrors(__FILE__, __LINE__), GL_NO_ERROR);
+}
+
+//
+// AlphaToCoverageToggle
+//
+// Verify that GL_SAMPLE_ALPHA_TO_COVERAGE follows the most recently bound
+// pipeline. This is the actual production scenario: pipelines are switched
+// between draw calls and the GL state must track each one.
+//
+TEST_F(RenderStateApplicationOGLTest, AlphaToCoverageToggle) {
+  // Start by enabling A2C.
+  bindPipelineWithAlphaToCoverage(true);
+  GLboolean a2cEnabled = GL_FALSE;
+  context_->getBooleanv(GL_SAMPLE_ALPHA_TO_COVERAGE, &a2cEnabled);
+  ASSERT_EQ(a2cEnabled, GL_TRUE);
+
+  // Bind a different pipeline that disables A2C; the GL state must follow.
+  bindPipelineWithAlphaToCoverage(false);
+  context_->getBooleanv(GL_SAMPLE_ALPHA_TO_COVERAGE, &a2cEnabled);
+  ASSERT_EQ(a2cEnabled, GL_FALSE);
+
+  // And back on again.
+  bindPipelineWithAlphaToCoverage(true);
+  context_->getBooleanv(GL_SAMPLE_ALPHA_TO_COVERAGE, &a2cEnabled);
+  ASSERT_EQ(a2cEnabled, GL_TRUE);
+
+  ASSERT_EQ(context_->checkForErrors(__FILE__, __LINE__), GL_NO_ERROR);
 }
 
 } // namespace igl::tests

--- a/src/igl/tests/vulkan/VulkanPipelineBuilderTest.cpp
+++ b/src/igl/tests/vulkan/VulkanPipelineBuilderTest.cpp
@@ -140,6 +140,16 @@ TEST_F(VulkanPipelineBuilderTest, RasterizationSamples) {
   EXPECT_EQ(&result, &builder);
 }
 
+TEST_F(VulkanPipelineBuilderTest, AlphaToCoverageEnable) {
+  igl::vulkan::VulkanPipelineBuilder builder1;
+  auto& r1 = builder1.alphaToCoverageEnable(true);
+  EXPECT_EQ(&r1, &builder1);
+
+  igl::vulkan::VulkanPipelineBuilder builder2;
+  auto& r2 = builder2.alphaToCoverageEnable(false);
+  EXPECT_EQ(&r2, &builder2);
+}
+
 TEST_F(VulkanPipelineBuilderTest, DynamicStateSingle) {
   igl::vulkan::VulkanPipelineBuilder builder;
   auto& result = builder.dynamicState(VK_DYNAMIC_STATE_VIEWPORT);

--- a/src/igl/vulkan/RenderPipelineState.cpp
+++ b/src/igl/vulkan/RenderPipelineState.cpp
@@ -557,6 +557,7 @@ VkPipeline RenderPipelineState::getVkPipeline(
           .depthCompareOp(dynamicState.getDepthCompareOp(), dynamicState.depthWriteEnable)
           .depthWriteEnable(dynamicState.depthWriteEnable)
           .rasterizationSamples(getVulkanSampleCountFlags(desc_.sampleCount))
+          .alphaToCoverageEnable(desc_.alphaToCoverageEnabled)
           .polygonMode(polygonFillModeToVkPolygonMode(desc_.polygonFillMode))
           .stencilStateOps(VK_STENCIL_FACE_FRONT_BIT,
                            dynamicState.getStencilStateFailOp(true),

--- a/src/igl/vulkan/VulkanPipelineBuilder.cpp
+++ b/src/igl/vulkan/VulkanPipelineBuilder.cpp
@@ -92,6 +92,11 @@ VulkanPipelineBuilder& VulkanPipelineBuilder::rasterizationSamples(VkSampleCount
   return *this;
 }
 
+VulkanPipelineBuilder& VulkanPipelineBuilder::alphaToCoverageEnable(bool enable) {
+  multisampleState_.alphaToCoverageEnable = enable ? VK_TRUE : VK_FALSE;
+  return *this;
+}
+
 VulkanPipelineBuilder& VulkanPipelineBuilder::cullMode(VkCullModeFlags mode) {
   rasterizationState_.cullMode = mode;
   return *this;

--- a/src/igl/vulkan/VulkanPipelineBuilder.h
+++ b/src/igl/vulkan/VulkanPipelineBuilder.h
@@ -25,6 +25,7 @@ class VulkanPipelineBuilder final {
   VulkanPipelineBuilder& dynamicStates(const std::vector<VkDynamicState>& states);
   VulkanPipelineBuilder& primitiveTopology(VkPrimitiveTopology topology);
   VulkanPipelineBuilder& rasterizationSamples(VkSampleCountFlagBits samples);
+  VulkanPipelineBuilder& alphaToCoverageEnable(bool enable);
   VulkanPipelineBuilder& shaderStage(VkPipelineShaderStageCreateInfo stage);
   VulkanPipelineBuilder& shaderStages(const std::vector<VkPipelineShaderStageCreateInfo>& stages);
   VulkanPipelineBuilder& stencilStateOps(VkStencilFaceFlags faceMask,


### PR DESCRIPTION
Closes #394

This PR adds Alpha-to-Coverage (A2C) support to `igl::RenderPipelineDesc`, plumbing the new `alphaToCoverageEnabled` flag through all four rendering backends (Vulkan, Metal, D3D12, OpenGL).
