### PR TITLE
igl | opengl | Call glInvalidateFramebuffer() if attachment.storeAction != StoreAction::Store.

### DIFF
--- a/src/igl/opengl/RenderCommandEncoder.cpp
+++ b/src/igl/opengl/RenderCommandEncoder.cpp
@@ -300,6 +300,7 @@ void RenderCommandEncoder::endEncoding() {
         IGL_DEBUG_ASSERT_NOT_REACHED();
       }
     }
+    framebuffer_->unbind();
   }
 }
 


### PR DESCRIPTION
The previous attempt to add this line before BlitFramebuffer(https://github.com/vinsentli/igl/commit/4e14b8ecc40d5d43d1a4ea539c5c1f3c5fca16d2) caused errors and was reverted(https://github.com/vinsentli/igl/commit/980e4e90a06d45fafd064cc1216521d59d4a1712). Placing it after the blit operation ensures the framebuffer state is valid during the copy.