### PR TITLE
igl | vulkan | fix: Correct format conversion between AHARDWAREBUFFER_FORMAT and igl::TextureFormat for R5G6B5_UNorm

### DIFF
--- a/src/igl/android/NativeHWBuffer.cpp
+++ b/src/igl/android/NativeHWBuffer.cpp
@@ -24,7 +24,6 @@ uint32_t getNativeHWFormat(TextureFormat iglFormat) {
     return AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
 
   case TextureFormat::R5G6B5_UNorm:
-  case TextureFormat::B5G6R5_UNorm:
     return AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM;
 
   case TextureFormat::RGBA_F16:
@@ -87,7 +86,7 @@ TextureFormat getIglFormat(uint32_t nativeFormat) {
     return TextureFormat::RGBA_UNorm8;
 
   case AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM:
-    return TextureFormat::B5G6R5_UNorm;
+    return TextureFormat::R5G6B5_UNorm;
 
   case AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT:
     return TextureFormat::RGBA_F16;


### PR DESCRIPTION
Initially, IGL only supported the TextureFormat::B5G6R5_UNorm format, so AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM was mapped to TextureFormat::B5G6R5_UNorm.

Later, I introduced TextureFormat::R5G6B5_UNorm(https://github.com/facebook/igl/pull/358), which introduced a mapping conflict: both TextureFormat::R5G6B5_UNorm and TextureFormat::B5G6R5_UNorm were forwarded to AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM, while the reverse mapping (from AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM back to an IGL texture format) could only resolve to TextureFormat::B5G6R5_UNorm.

To fix this, I’ve standardized the mapping to exclusively pair AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM with TextureFormat::R5G6B5_UNorm.

⚠️ This is a breaking change: It may require migration work for existing users who previously relied on TextureFormat::B5G6R5_UNorm for Android Hardware Buffer workflows. Please carefully assess whether to merge this PR.