### PR TITLE
igl | vulkan | merge storage image reflection data across shader stages

### DIFF
--- a/src/igl/vulkan/util/SpvReflection.cpp
+++ b/src/igl/vulkan/util/SpvReflection.cpp
@@ -305,6 +305,7 @@ SpvModuleInfo mergeReflectionData(const SpvModuleInfo& info1, const SpvModuleInf
 
   combineDescriptions(result.buffers, info1.buffers, info2.buffers);
   combineDescriptions(result.textures, info1.textures, info2.textures);
+  combineDescriptions(result.images, info1.images, info2.images);
 
   result.hasPushConstants = info1.hasPushConstants || info2.hasPushConstants;
   result.usageMaskBuffers = info1.usageMaskBuffers | info2.usageMaskBuffers;


### PR DESCRIPTION
`mergeReflectionData()` in `SpvReflection.cpp` combined the `buffers` and `textures` vectors from the two `SpvModuleInfo` inputs but never combined `images` (storage images). the merged reflection is what graphics and mesh pipelines use, so their `images` vector was always empty. compute pipelines were unaffected because they consume a single module's `SpvModuleInfo` directly.

as a consequence, `PipelineState` skipped every `VK_DESCRIPTOR_TYPE_STORAGE_IMAGE` binding for graphics and mesh pipelines. a fragment, vertex, or mesh shader declaring a storage image (for example `layout(rgba8, binding = N) uniform image2D`) received no descriptor set layout binding, leading to failed bindings and validation errors.

this change merges `images` the same way as `buffers` and `textures`.