### PR TITLE
igl | vulkan | fix out-of-bounds check and staging accounting in getBufferSubData()

### DIFF
--- a/src/igl/vulkan/VulkanStagingDevice.cpp
+++ b/src/igl/vulkan/VulkanStagingDevice.cpp
@@ -297,15 +297,20 @@ void VulkanStagingDevice::getBufferSubData(const VulkanBuffer& buffer,
     // Wait for command to finish
     immediate->wait(immediate->submit(wrapper), ctx_.config_.fenceTimeoutNanoseconds);
 
-    // Copy data into data
+    // Copy data into data. `size` is the number of bytes still to be written into `data`, which is
+    // exactly the remaining capacity of `dstData` (it starts at `bufferSize` and is decremented by
+    // `copySize` each iteration). `copySize` is always <= `size`, so this bound is correct even when
+    // `srcOffset` is non-zero.
     const uint8_t* src = stagingBuffer->getMappedPtr() + memoryChunk.offset;
-    checked_memcpy(dstData, bufferSize - chunkSrcOffset, src, copySize);
+    checked_memcpy(dstData, size, src, copySize);
 
     size -= copySize;
     dstData += copySize;
     chunkSrcOffset += copySize;
 
+    // the transfer has completed above, so the staging block is free again
     regions_.push_back(memoryChunk);
+    freeStagingBufferSize_ += memoryChunk.size;
   }
 }
 


### PR DESCRIPTION
two independent issues in `VulkanStagingDevice::getBufferSubData()`.

first, the `checked_memcpy()` destination size was computed as `bufferSize - chunkSrcOffset`, but `chunkSrcOffset` starts at `srcOffset` rather than 0, so it under-reported the remaining capacity of `data` by `srcOffset` bytes. for a single-chunk readback where `copySize == size` and `srcOffset > 0`, this made `destination_size < count`, and `checked_memcpy()` calls `exit(EXIT_FAILURE)`. this is reachable through `Buffer::map()` on a device-local buffer with a non-zero range offset, which downloads via `getBufferSubData(buffer, range.offset, range.size, tmpBuffer_.data())`. the fix uses the loop's remaining `size`, which is exactly the remaining capacity of `data` and is always >= `copySize`.

second, the staging block was pushed back onto `regions_` after the transfer completed, but `freeStagingBufferSize_` was never credited, unlike the equivalent wait-then-push path in `getImageData2D()`. because the region is pushed with an empty submit handle, `mergeRegionsAndFreeBuffers()` never credits it either, so `freeStagingBufferSize_` leaks on every readback and can underflow. the fix restores `freeStagingBufferSize_` after the wait, matching `getImageData2D()`.