### PR TITLE
[C0] igl | Introduce API : RenderCommandEncoder::setCullMode()

### DIFF
--- a/src/igl/RenderCommandEncoder.h
+++ b/src/igl/RenderCommandEncoder.h
@@ -109,10 +109,7 @@ class IRenderCommandEncoder : public ICommandEncoder {
 
   virtual void setStencilReferenceValue(uint32_t value) = 0;
   virtual void setBlendColor(const Color& color) = 0;
-  /// Overrides the cull mode baked into the currently bound pipeline state.
-  /// Only Metal, Vulkan and OpenGL implement this today; other backends
-  /// (e.g. D3D12) may keep the default implementation.
-  virtual void setCullMode(CullMode /*cullMode*/) {}
+  virtual void setCullMode(CullMode cullMode) = 0;
   virtual void setDepthBias(float depthBias, float slopeScale, float clamp) = 0;
 };
 

--- a/src/igl/RenderCommandEncoder.h
+++ b/src/igl/RenderCommandEncoder.h
@@ -109,6 +109,10 @@ class IRenderCommandEncoder : public ICommandEncoder {
 
   virtual void setStencilReferenceValue(uint32_t value) = 0;
   virtual void setBlendColor(const Color& color) = 0;
+  /// Overrides the cull mode baked into the currently bound pipeline state.
+  /// Only Metal, Vulkan and OpenGL implement this today; other backends
+  /// (e.g. D3D12) may keep the default implementation.
+  virtual void setCullMode(CullMode /*cullMode*/) {}
   virtual void setDepthBias(float depthBias, float slopeScale, float clamp) = 0;
 };
 

--- a/src/igl/d3d12/RenderCommandEncoder.h
+++ b/src/igl/d3d12/RenderCommandEncoder.h
@@ -93,6 +93,7 @@ class RenderCommandEncoder final : public IRenderCommandEncoder {
 
   void setStencilReferenceValue(uint32_t value) override;
   void setBlendColor(const Color& color) override;
+  void setCullMode(CullMode cullMode) override {}
   void setDepthBias(float depthBias, float slopeScale, float clamp) override;
 
   // ICommandEncoder interface

--- a/src/igl/metal/RenderCommandEncoder.h
+++ b/src/igl/metal/RenderCommandEncoder.h
@@ -83,6 +83,7 @@ class RenderCommandEncoder final : public IRenderCommandEncoder {
 
   void setStencilReferenceValue(uint32_t value) override;
   void setBlendColor(const Color& color) override;
+  void setCullMode(CullMode cullMode) override {}
   void setDepthBias(float depthBias, float slopeScale, float clamp) override;
 
   static MTLPrimitiveType convertPrimitiveType(PrimitiveType value);

--- a/src/igl/opengl/RenderCommandEncoder.h
+++ b/src/igl/opengl/RenderCommandEncoder.h
@@ -99,6 +99,7 @@ class RenderCommandEncoder final : public IRenderCommandEncoder, public WithCont
 
   void setStencilReferenceValue(uint32_t value) override;
   void setBlendColor(const Color& color) override;
+  void setCullMode(CullMode cullMode) override {}
   void setDepthBias(float depthBias, float slopeScale, float clamp) override;
 
  private:

--- a/src/igl/vulkan/RenderCommandEncoder.h
+++ b/src/igl/vulkan/RenderCommandEncoder.h
@@ -110,6 +110,7 @@ class RenderCommandEncoder : public IRenderCommandEncoder {
 
   void setStencilReferenceValue(uint32_t value) override;
   void setBlendColor(const Color& color) override;
+  void setCullMode(CullMode cullMode) override {}
   void setDepthBias(float depthBias, float slopeScale, float clamp) override;
 
   [[nodiscard]] VkCommandBuffer getVkCommandBuffer() const {


### PR DESCRIPTION
Introduce setCullModeAPI to decouple cull mode from the PSO and reduce PSO proliferation. The change is forward-compatible. No negative side effects.