### PR TITLE
Fix null-pointer dereference in BitmapWriter for unsupported backends

### DIFF
--- a/IGLU/bitmap/BitmapWriter.cpp
+++ b/IGLU/bitmap/BitmapWriter.cpp
@@ -103,6 +103,10 @@ void writeBitmap(std::ostream& stream,
       ::iglu::textureaccessor::TextureAccessorFactory::createTextureAccessor(
           device.getBackendType(), texture, device);
 
+  if (!IGL_DEBUG_VERIFY(textureAccessor)) {
+    return;
+  }
+
   const igl::CommandQueueDesc desc{};
   Result result;
   const auto commandQueue = device.createCommandQueue(desc, &result);


### PR DESCRIPTION
## What

`IGLU/bitmap/BitmapWriter.cpp` calls `TextureAccessorFactory::createTextureAccessor()` and then dereferences the result without checking it.

The factory only implements OpenGL, Metal and Vulkan. On any other backend (D3D12 on Windows, or Invalid/Custom) it hits the `default:` branch and returns `nullptr`. `writeBitmap()` then calls `textureAccessor->requestBytes(*commandQueue, nullptr)` on the null pointer.

In release builds this is a null-pointer dereference / crash; in debug builds the `IGL_DEBUG_ASSERT_NOT_IMPLEMENTED()` in the factory fires first.

## Why

`writeBitmap()` is advertised as a generic cross-backend helper. On a Windows D3D12 device (a first-class IGL backend) it is a guaranteed crash. The codebase's own error-handling convention (see IGL Error Handling rule #24 referenced in OpenGLTextureAccessor.cpp) requires guarding resource/accessor creation.

## How

Guard the accessor immediately after creation and return early when it is null:

```cpp
const auto textureAccessor =
    ::iglu::textureaccessor::TextureAccessorFactory::createTextureAccessor(
        device.getBackendType(), texture, device);

if (!IGL_DEBUG_VERIFY(textureAccessor)) {
  return;
}
```

This matches the `IGL_DEBUG_VERIFY(commandQueue)` null check already present in the same function.

## Test plan

- No new behavior change for OpenGL/Metal/Vulkan: the accessor is never null there, so the guard is a no-op.
- For D3D12 (and any future backend without an accessor), writeBitmap now returns cleanly instead of dereferencing null.

Verified by reading the real code paths: `IGLU/texture_accessor/TextureAccessorFactory.cpp` (no D3D12 case, `default:` returns nullptr) and `IGLU/bitmap/BitmapWriter.cpp` (unchecked dereference).